### PR TITLE
002 portfolio private content

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@ Unified cheat sheet so any AI agent (Claude Code, GPT, etc.) can understand the 
 - Semantic sections live under `src/components/sections/*` and each owns a stable `id`
   for in-page anchor navigation.
 - Content data is centralized in `src/content/portfolio.ts` for maintainability.
+  - Private overrides can be injected via env vars (no private content committed to git).
 
 ## Workflow Expectations
 - Branch from feature branch, open PR → merge to `main` → Vercel autodeploy.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ Focused tips for Anthropic Claude Code / Workbench agents interacting with this 
   - `PORTFOLIO_PRIVATE_JSON` (JSON string)
   - `PORTFOLIO_PRIVATE_URL` (+ optional `PORTFOLIO_PRIVATE_URL_BEARER`)
   - `PORTFOLIO_PRIVATE_REVALIDATE_SECONDS` (default 86400 = 24h cache)
+  - `PORTFOLIO_PRIVATE_TIMEOUT_MS` (default 3000 = 3s timeout)
 - `src/app/layout.tsx` – Imports NES.css, fonts, metadata; extend when adding OG tags or global providers.
 - `tailwind.config.js` – Update `content` array if adding directories.
 - `postcss.config.js` – Standard pipeline; modify when adding plugins like `postcss-nesting`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,11 @@ Focused tips for Anthropic Claude Code / Workbench agents interacting with this 
 - `src/app/page.tsx` – Landing page composition (Hero → TOC → sections). Keep it thin; put content in sections and data in `src/content/portfolio.ts`.
 - `src/components/TableOfContents.tsx` – TOC UI (in-page navigation).
 - `src/components/sections/*` – Semantic sections; each owns a stable `id` for `#hash` navigation.
-- `src/content/portfolio.ts` – Single source of truth for portfolio content (easy updates).
+- `src/content/portfolio.ts` – Public content + optional private overrides loaded server-side via env vars:
+  - `PORTFOLIO_PRIVATE_SOURCE` = `env` or `url`
+  - `PORTFOLIO_PRIVATE_JSON` (JSON string)
+  - `PORTFOLIO_PRIVATE_URL` (+ optional `PORTFOLIO_PRIVATE_URL_BEARER`)
+  - `PORTFOLIO_PRIVATE_REVALIDATE_SECONDS` (default 86400 = 24h cache)
 - `src/app/layout.tsx` – Imports NES.css, fonts, metadata; extend when adding OG tags or global providers.
 - `tailwind.config.js` – Update `content` array if adding directories.
 - `postcss.config.js` – Standard pipeline; modify when adding plugins like `postcss-nesting`.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,15 @@ When a change affects dependencies or workflows, remember to update README / doc
 ## Customizing next steps
 
 - Update the copy/data in `src/content/portfolio.ts` (profile/experience/projects/skills/contact).
+- If you want to keep some details off the public repo, you can provide private overrides via
+  environment variables (see `src/content/portfolio.ts`: `PORTFOLIO_PRIVATE_JSON` or
+  `PORTFOLIO_PRIVATE_URL`).
+  - For Google Sheets/Docs maintenance, a practical pattern is:
+    Google Sheet (Drive) → Google Apps Script Web App (JSON API + token) →
+    set `PORTFOLIO_PRIVATE_URL` + `PORTFOLIO_PRIVATE_URL_BEARER` +
+    `PORTFOLIO_PRIVATE_REVALIDATE_SECONDS=86400` (24h cache).
+  - Projects can include `visibility: "public" | "private"`. Private items will be redacted
+    on the public page (summary/outcome/link hidden).
 - Drop a `public/og.png` and extend `src/app/layout.tsx` metadata for richer previews.
 - Tweak NES colors or swap the background (`src/app/globals.css`) for other retro palettes.
 - Add new sections/components under `src/components` and include them via `@/` alias.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ When a change affects dependencies or workflows, remember to update README / doc
     `PORTFOLIO_PRIVATE_REVALIDATE_SECONDS=86400` (24h cache).
   - Projects can include `visibility: "public" | "private"`. Private items will be redacted
     on the public page (summary/outcome/link hidden).
+    - With current UI, `visibility="private"` also hides role/tech/outcome/link (title + badges only).
 - Drop a `public/og.png` and extend `src/app/layout.tsx` metadata for richer previews.
 - Tweak NES colors or swap the background (`src/app/globals.css`) for other retro palettes.
 - Add new sections/components under `src/components` and include them via `@/` alias.

--- a/specs/002-portfolio-private-content/apps-script/Code.gs
+++ b/specs/002-portfolio-private-content/apps-script/Code.gs
@@ -1,0 +1,116 @@
+// Google Apps Script (Web App) - Bearer-protected JSON for portfolio overrides
+//
+// Setup:
+// - Script Properties: BEARER_TOKEN = random long string
+// - Deploy as Web App: Execute as Me, Access Anyone (Bearer guards access)
+//
+// Sheets:
+// - "experience": headers [year, text]
+// - "projects": headers:
+//   [visibility,title,summary,role,tech,outcomeOrLearning,status,linkLabel,linkHref]
+
+const SHEET_EXPERIENCE = "experience";
+const SHEET_PROJECTS = "projects";
+
+function getBearerToken_() {
+  return PropertiesService.getScriptProperties().getProperty("BEARER_TOKEN");
+}
+
+function unauthorized_(status, body) {
+  const output = ContentService.createTextOutput(JSON.stringify(body));
+  output.setMimeType(ContentService.MimeType.JSON);
+  // Note: ContentService doesn't support setting HTTP status codes directly.
+  // Clients should treat this as an error based on the response body.
+  return output;
+}
+
+function assertAuthorized_(e) {
+  const header =
+    (e && e.headers && (e.headers.Authorization || e.headers.authorization)) || "";
+  const token = getBearerToken_();
+  if (!token) return { ok: false, body: { error: "Server not configured" } };
+  if (header !== `Bearer ${token}`) return { ok: false, body: { error: "Unauthorized" } };
+  return { ok: true };
+}
+
+function sheetToObjects_(sheet) {
+  const values = sheet.getDataRange().getValues();
+  if (values.length < 2) return [];
+  const headers = values[0].map(String);
+  return values.slice(1).map((row) => {
+    const obj = {};
+    headers.forEach((h, i) => {
+      obj[h] = row[i];
+    });
+    return obj;
+  });
+}
+
+function normalizeExperience_(rows) {
+  return rows
+    .filter((r) => r.year && r.text)
+    .map((r) => ({
+      year: String(r.year),
+      text: String(r.text),
+    }));
+}
+
+function normalizeProjects_(rows) {
+  return rows
+    .filter((r) => r.title)
+    .map((r) => {
+      const visibility = r.visibility ? String(r.visibility) : "public";
+      return {
+        visibility,
+        title: String(r.title),
+        summary: String(r.summary || ""),
+        role: String(r.role || ""),
+        tech: String(r.tech || "")
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean),
+        outcomeOrLearning: String(r.outcomeOrLearning || ""),
+        status: r.status ? String(r.status) : undefined,
+        link:
+          r.linkHref && r.linkLabel
+            ? { href: String(r.linkHref), label: String(r.linkLabel) }
+            : undefined,
+      };
+    });
+}
+
+function doGet(e) {
+  const auth = assertAuthorized_(e);
+  if (!auth.ok) return unauthorized_(401, auth.body);
+
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  const expSheet = ss.getSheetByName(SHEET_EXPERIENCE);
+  const projSheet = ss.getSheetByName(SHEET_PROJECTS);
+  if (!expSheet || !projSheet) {
+    return unauthorized_(400, {
+      error: "Missing sheets",
+      required: [SHEET_EXPERIENCE, SHEET_PROJECTS],
+    });
+  }
+
+  const expRows = sheetToObjects_(expSheet);
+  const projRows = sheetToObjects_(projSheet);
+
+  // Return Partial<Portfolio> (only the parts you want to override)
+  const payload = {
+    experience: {
+      heading: "Experience",
+      highlights: normalizeExperience_(expRows),
+    },
+    projects: {
+      heading: "Projects",
+      items: normalizeProjects_(projRows),
+    },
+  };
+
+  const output = ContentService.createTextOutput(JSON.stringify(payload));
+  output.setMimeType(ContentService.MimeType.JSON);
+  return output;
+}
+
+

--- a/specs/002-portfolio-private-content/quickstart.md
+++ b/specs/002-portfolio-private-content/quickstart.md
@@ -1,0 +1,78 @@
+# Quickstart: Private content via Google Sheets (Bearer) + 24h cache
+
+## Goal
+
+Keep Experience/Projects in Google Sheets (Drive) while keeping the GitHub repo public.
+The site loads **private overrides server-side** via a Bearer-protected JSON endpoint,
+and caches responses for 24 hours by default.
+
+## 1) Create Google Sheet (template)
+
+Create a new spreadsheet with two sheets:
+
+### Sheet: `experience`
+
+Header row:
+
+- `year`
+- `text`
+
+Example rows:
+
+- `2024` | `バックエンド開発（Go）。運用改善と開発体験の両立に取り組む`
+
+### Sheet: `projects`
+
+Header row:
+
+- `visibility` (`public` or `private`; optional, defaults to `public`)
+- `title`
+- `summary` (optional; ignored when `visibility=private`)
+- `role` (optional; ignored when `visibility=private`)
+- `tech` (comma-separated; optional; ignored when `visibility=private`)
+- `outcomeOrLearning` (optional; ignored when `visibility=private`)
+- `status` (optional)
+- `linkLabel` (optional; ignored when `visibility=private`)
+- `linkHref` (optional; ignored when `visibility=private`)
+
+## 2) Create Apps Script Web App (Bearer protected JSON)
+
+In the Spreadsheet: **Extensions → Apps Script**.
+
+Set Script Properties:
+
+- `BEARER_TOKEN`: random long string (do not commit)
+
+Implement `doGet(e)`:
+
+- Check `Authorization: Bearer <token>`
+- Read the spreadsheet
+- Return JSON shaped as `Partial<Portfolio>` (only overrides you need), e.g.:
+  - `experience: { heading, highlights }`
+  - `projects: { heading, items }`
+
+Deploy:
+
+- Deploy → New deployment → Web app
+- Execute as: **Me**
+- Who has access: **Anyone** (Bearer gate protects it)
+
+Copy the Web App URL.
+
+## 3) Configure Vercel env vars
+
+Set:
+
+- `PORTFOLIO_PRIVATE_SOURCE=url`
+- `PORTFOLIO_PRIVATE_URL=<your web app url>`
+- `PORTFOLIO_PRIVATE_URL_BEARER=<your bearer token>`
+- `PORTFOLIO_PRIVATE_REVALIDATE_SECONDS=86400`
+
+## 4) Verify behavior
+
+1. Open the site and confirm Experience/Projects reflect sheet values.
+2. Change a sheet row and confirm it **does not** update immediately (cache).
+3. To force fast iteration temporarily, set:
+   - `PORTFOLIO_PRIVATE_REVALIDATE_SECONDS=0`
+
+

--- a/specs/002-portfolio-private-content/quickstart.md
+++ b/specs/002-portfolio-private-content/quickstart.md
@@ -1,9 +1,9 @@
-# Quickstart: Private content via Google Sheets (Bearer) + 24h cache
+# Quickstart: Private content via Google Sheets (POST token) + 24h cache
 
 ## Goal
 
 Keep Experience/Projects in Google Sheets (Drive) while keeping the GitHub repo public.
-The site loads **private overrides server-side** via a Bearer-protected JSON endpoint,
+The site loads **private overrides server-side** via a token-protected JSON endpoint,
 and caches responses for 24 hours by default.
 
 ## 1) Create Google Sheet (template)
@@ -35,7 +35,7 @@ Header row:
 - `linkLabel` (optional; ignored when `visibility=private`)
 - `linkHref` (optional; ignored when `visibility=private`)
 
-## 2) Create Apps Script Web App (Bearer protected JSON)
+## 2) Create Apps Script Web App (POST body token protected JSON)
 
 In the Spreadsheet: **Extensions → Apps Script**.
 
@@ -43,10 +43,11 @@ Set Script Properties:
 
 - `BEARER_TOKEN`: random long string (do not commit)
 
-Implement `doGet(e)`:
+Implement `doPost(e)`:
 
-- Check `?token=<token>` (recommended; Apps Script does not reliably expose Authorization header)
-- (Optional) Also accept `Authorization: Bearer <token>` as a fallback if headers are available
+- Read JSON body: `{ "token": "<secret>" }`
+- Compare against Script Property `BEARER_TOKEN`
+- (Optional) Also accept `Authorization: Bearer <token>` as a best-effort fallback
 - Read the spreadsheet
 - Return JSON shaped as `Partial<Portfolio>` (only overrides you need), e.g.:
   - `experience: { heading, highlights }`
@@ -75,3 +76,11 @@ Set:
 2. Change a sheet row and confirm it **does not** update immediately (cache).
 3. To force fast iteration temporarily, set:
    - `PORTFOLIO_PRIVATE_REVALIDATE_SECONDS=0`
+
+### Quick API test (local)
+
+```bash
+curl -L -X POST -H "Content-Type: application/json" \
+  -d '{"token":"<your bearer token>"}' \
+  "<your apps script web app url>"
+```

--- a/specs/002-portfolio-private-content/quickstart.md
+++ b/specs/002-portfolio-private-content/quickstart.md
@@ -45,7 +45,8 @@ Set Script Properties:
 
 Implement `doGet(e)`:
 
-- Check `Authorization: Bearer <token>`
+- Check `?token=<token>` (recommended; Apps Script does not reliably expose Authorization header)
+- (Optional) Also accept `Authorization: Bearer <token>` as a fallback if headers are available
 - Read the spreadsheet
 - Return JSON shaped as `Partial<Portfolio>` (only overrides you need), e.g.:
   - `experience: { heading, highlights }`
@@ -74,5 +75,3 @@ Set:
 2. Change a sheet row and confirm it **does not** update immediately (cache).
 3. To force fast iteration temporarily, set:
    - `PORTFOLIO_PRIVATE_REVALIDATE_SECONDS=0`
-
-

--- a/specs/002-portfolio-private-content/quickstart.md
+++ b/specs/002-portfolio-private-content/quickstart.md
@@ -61,6 +61,11 @@ Deploy:
 
 Copy the Web App URL.
 
+### IMPORTANT: After editing Code.gs, redeploy
+
+If you change `Code.gs`, you MUST redeploy (edit deployment or create a new deployment),
+otherwise the Web App may keep serving an older version (e.g., GET-only / no doPost).
+
 ## 3) Configure Vercel env vars
 
 Set:
@@ -84,3 +89,6 @@ curl -L -X POST -H "Content-Type: application/json" \
   -d '{"token":"<your bearer token>"}' \
   "<your apps script web app url>"
 ```
+
+If you still see HTML or `405 Allow: GET, HEAD`, the deployment is not updated or the URL is not
+the Web App URL.

--- a/specs/002-portfolio-private-content/quickstart.md
+++ b/specs/002-portfolio-private-content/quickstart.md
@@ -85,7 +85,7 @@ Set:
 ### Quick API test (local)
 
 ```bash
-curl -L -X POST -H "Content-Type: application/json" \
+curl -i -L -H "Content-Type: application/json" \
   -d '{"token":"<your bearer token>"}' \
   "<your apps script web app url>"
 ```

--- a/specs/002-portfolio-private-content/spec.md
+++ b/specs/002-portfolio-private-content/spec.md
@@ -1,0 +1,85 @@
+# Feature Specification: 外部データ（Google Sheets）で経験・実績を管理し、公開/非公開を制御する
+
+**Feature Branch**: `002-portfolio-private-content`  
+**Created**: 2025-12-24  
+**Status**: Draft  
+**Input**: User description: "外部データ（Google Sheets/Apps Script）から経験・実績を注入し、公開/非公開を制御する"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - 公開RepoにPrivate情報を置かずに、内容を更新できる (Priority: P1)
+
+サイトオーナーとして、Experience/Projects の詳細を Google Sheets 上で管理し、
+公開GitHubリポジトリにPrivate情報をコミットせずにサイトへ反映したい。
+
+**Why this priority**: Private情報の漏洩は取り返しがつかないため、運用の安全性が最重要。
+
+**Independent Test**: Sheetのデータを変更しても、リポジトリにPrivate内容を置かずにサイト表示を更新できる。
+
+**Acceptance Scenarios**:
+
+1. **Given** Privateデータが外部URLまたは環境変数で提供されている、**When** サイトが表示される、**Then** Publicに加えてPrivate上書きが反映される
+2. **Given** Privateデータ取得に失敗する（認証/ネットワーク等）、**When** サイトが表示される、**Then** Publicデータにフォールバックしてサイトは壊れない
+
+---
+
+### User Story 2 - Private実績は必要最低限だけ公開する (Priority: P2)
+
+サイトオーナーとして、NDA等の理由で公開したくない実績は “Private” として扱い、
+タイトルなどの最小情報にとどめたい。
+
+**Why this priority**: 実績の価値は伝えつつ、守るべき情報は守りたい。
+
+**Independent Test**: `visibility="private"` のプロジェクトがUI上でredactされることを確認できる。
+
+**Acceptance Scenarios**:
+
+1. **Given** `visibility="private"` のプロジェクトが存在する、**When** Projectsを開く、**Then** 詳細（summary/outcome/link等）が表示されない
+
+---
+
+### User Story 3 - 外部データ取得をキャッシュし、運用負荷を下げる (Priority: P3)
+
+サイトオーナーとして、外部データ取得が毎リクエストで走らないようにし、
+上流（Apps Script等）への負荷と遅延を抑えたい。
+
+**Why this priority**: 外部データ元は落ちやすく/遅くなりやすいので、サイト表示の安定性を上げたい。
+
+**Independent Test**: キャッシュ期間（例: 24h）を設定でき、頻繁に外部取得しないことを確認できる。
+
+**Acceptance Scenarios**:
+
+1. **Given** キャッシュ期間が設定されている、**When** サイトが短時間に複数回表示される、**Then** 外部データの取得回数が抑制される
+
+---
+
+### Edge Cases
+
+- 外部データのJSONが壊れている/スキーマが違う
+- Bearerトークンが漏れた/無効化したい
+- 外部データが遅い/落ちている（タイムアウト含む）
+- キャッシュ中に更新が反映されない（運用上の期待値調整）
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: システムはPublicデータを常に表示できなければならない（外部データがなくてもサイトは成立する）
+- **FR-002**: システムは外部データ（URLまたは環境変数）を用いてPublicデータを上書きできなければならない
+- **FR-003**: 外部データ取得が失敗した場合、システムはPublicデータにフォールバックしなければならない
+- **FR-004**: Projectsは `visibility` を持ち、`private` のものは公開ページ上で詳細を表示してはならない
+- **FR-005**: システムは外部データ取得をキャッシュできなければならない（例: 24時間）
+
+### Key Entities *(include if feature involves data)*
+
+- **Portfolio (Partial)**: 外部データとして注入される上書きデータ（Experience/Projects等の一部でも可）
+- **Project.visibility**: `public | private`（公開ページでの開示レベル）
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Publicデータのみでサイトが常に表示できる（外部データがなくても壊れない）
+- **SC-002**: 外部データを使って Experience/Projects の表示が更新できる
+- **SC-003**: `visibility="private"` のプロジェクトで、summary/outcome/link 等の詳細が公開されない
+- **SC-004**: キャッシュ（例: 24h）により外部データ取得頻度が抑制される

--- a/src/components/sections/ContactSection.tsx
+++ b/src/components/sections/ContactSection.tsx
@@ -1,10 +1,11 @@
-import { contact } from "@/content/portfolio";
+import { getPortfolio } from "@/content/portfolio";
 
 function isExternalHttpHref(href: string) {
   return href.startsWith("http://") || href.startsWith("https://");
 }
 
-export function ContactSection() {
+export async function ContactSection() {
+  const { contact } = await getPortfolio();
   return (
     <section
       id={contact.id}

--- a/src/components/sections/ExperienceSection.tsx
+++ b/src/components/sections/ExperienceSection.tsx
@@ -1,6 +1,7 @@
-import { experience } from "@/content/portfolio";
+import { getPortfolio } from "@/content/portfolio";
 
-export function ExperienceSection() {
+export async function ExperienceSection() {
+  const { experience } = await getPortfolio();
   return (
     <section
       id={experience.id}

--- a/src/components/sections/ProfileSection.tsx
+++ b/src/components/sections/ProfileSection.tsx
@@ -1,6 +1,7 @@
-import { profile } from "@/content/portfolio";
+import { getPortfolio } from "@/content/portfolio";
 
-export function ProfileSection() {
+export async function ProfileSection() {
+  const { profile } = await getPortfolio();
   return (
     <section
       id={profile.id}

--- a/src/components/sections/ProjectsSection.tsx
+++ b/src/components/sections/ProjectsSection.tsx
@@ -1,6 +1,7 @@
-import { projects } from "@/content/portfolio";
+import { getPortfolio } from "@/content/portfolio";
 
-export function ProjectsSection() {
+export async function ProjectsSection() {
+  const { projects } = await getPortfolio();
   return (
     <section
       id={projects.id}
@@ -20,6 +21,8 @@ export function ProjectsSection() {
 
       <div className="mt-4 grid gap-4 md:grid-cols-2">
         {projects.items.map((project) => (
+          // `visibility` defaults to "public" if omitted
+          // Private items should avoid disclosing sensitive details.
           <article
             key={project.title}
             className="frame bg-[#1b1b1b] p-4 text-fami-ivory"
@@ -31,15 +34,24 @@ export function ProjectsSection() {
               >
                 {project.title}
               </h3>
-              {project.status ? (
-                <span className="nes-badge is-primary text-[0.6rem]">
-                  <span>{project.status}</span>
-                </span>
-              ) : null}
+              <div className="flex items-center gap-2">
+                {project.visibility === "private" ? (
+                  <span className="nes-badge is-error text-[0.6rem]">
+                    <span>PRIVATE</span>
+                  </span>
+                ) : null}
+                {project.status ? (
+                  <span className="nes-badge is-primary text-[0.6rem]">
+                    <span>{project.status}</span>
+                  </span>
+                ) : null}
+              </div>
             </div>
 
             <p className="mt-2 text-sm [font-family:var(--font-noto)]">
-              {project.summary}
+              {project.visibility === "private"
+                ? "詳細は面談でお話しできます（NDA等に配慮）。"
+                : project.summary}
             </p>
 
             <dl className="mt-3 space-y-2 text-xs [font-family:var(--font-noto)]">
@@ -57,13 +69,15 @@ export function ProjectsSection() {
                   ))}
                 </dd>
               </div>
-              <div className="flex gap-2">
-                <dt className="w-20 text-fami-gold">Outcome</dt>
-                <dd>{project.outcomeOrLearning}</dd>
-              </div>
+              {project.visibility === "private" ? null : (
+                <div className="flex gap-2">
+                  <dt className="w-20 text-fami-gold">Outcome</dt>
+                  <dd>{project.outcomeOrLearning}</dd>
+                </div>
+              )}
             </dl>
 
-            {project.link ? (
+            {project.visibility === "private" ? null : project.link ? (
               <a
                 className="nes-btn mt-4 w-full text-center"
                 href={project.link.href}

--- a/src/components/sections/ProjectsSection.tsx
+++ b/src/components/sections/ProjectsSection.tsx
@@ -54,28 +54,28 @@ export async function ProjectsSection() {
                 : project.summary}
             </p>
 
-            <dl className="mt-3 space-y-2 text-xs [font-family:var(--font-noto)]">
-              <div className="flex gap-2">
-                <dt className="w-20 text-fami-gold">Role</dt>
-                <dd>{project.role}</dd>
-              </div>
-              <div className="flex gap-2">
-                <dt className="w-20 text-fami-gold">Tech</dt>
-                <dd className="flex flex-wrap gap-1">
-                  {project.tech.map((t) => (
-                    <span key={t} className="nes-badge is-warning text-[0.55rem]">
-                      <span>{t}</span>
-                    </span>
-                  ))}
-                </dd>
-              </div>
-              {project.visibility === "private" ? null : (
+            {project.visibility === "private" ? null : (
+              <dl className="mt-3 space-y-2 text-xs [font-family:var(--font-noto)]">
+                <div className="flex gap-2">
+                  <dt className="w-20 text-fami-gold">Role</dt>
+                  <dd>{project.role}</dd>
+                </div>
+                <div className="flex gap-2">
+                  <dt className="w-20 text-fami-gold">Tech</dt>
+                  <dd className="flex flex-wrap gap-1">
+                    {project.tech.map((t) => (
+                      <span key={t} className="nes-badge is-warning text-[0.55rem]">
+                        <span>{t}</span>
+                      </span>
+                    ))}
+                  </dd>
+                </div>
                 <div className="flex gap-2">
                   <dt className="w-20 text-fami-gold">Outcome</dt>
                   <dd>{project.outcomeOrLearning}</dd>
                 </div>
-              )}
-            </dl>
+              </dl>
+            )}
 
             {project.visibility === "private" ? null : project.link ? (
               <a

--- a/src/components/sections/SkillsSection.tsx
+++ b/src/components/sections/SkillsSection.tsx
@@ -1,6 +1,7 @@
-import { skills } from "@/content/portfolio";
+import { getPortfolio } from "@/content/portfolio";
 
-export function SkillsSection() {
+export async function SkillsSection() {
+  const { skills } = await getPortfolio();
   return (
     <section
       id={skills.id}

--- a/src/content/portfolio.ts
+++ b/src/content/portfolio.ts
@@ -1,3 +1,5 @@
+import "server-only";
+
 import type { TocItemId } from "@/components/toc";
 
 export type ExternalLink = {
@@ -5,7 +7,10 @@ export type ExternalLink = {
   href: string;
 };
 
+export type Visibility = "public" | "private";
+
 export type Project = {
+  visibility?: Visibility; // default: "public"
   title: string;
   summary: string;
   role: string;
@@ -30,68 +35,162 @@ export type SectionContent = {
   heading: string;
 };
 
-export const profile: SectionContent & { body: string } = {
-  id: "profile",
-  heading: "Profile",
-  body:
-    "ファミコン時代のときめきを UI/UX に落とし込むフロントエンドエンジニア。レトロな見た目と、今のプロダクトに必要な体験設計を両立させます。",
+export type Profile = SectionContent & { body: string };
+export type Experience = SectionContent & { highlights: ExperienceHighlight[] };
+export type Projects = SectionContent & { items: Project[] };
+export type Skills = SectionContent & { items: Skill[] };
+export type Contact = SectionContent & { blurb: string; links: ExternalLink[] };
+
+export type Portfolio = {
+  profile: Profile;
+  experience: Experience;
+  projects: Projects;
+  skills: Skills;
+  contact: Contact;
 };
 
-export const experience: SectionContent & { highlights: ExperienceHighlight[] } = {
-  id: "experience",
-  heading: "Experience",
-  highlights: [
-    { year: "2025", text: "プロダクトの体験設計と実装を横断してリード" },
-    { year: "2024", text: "デザインシステム/コンポーネント整備で開発速度を改善" },
-    { year: "2023", text: "Next.js を中心にフロント基盤を刷新" },
-  ],
+export const publicPortfolio: Portfolio = {
+  profile: {
+    id: "profile",
+    heading: "Profile",
+    body:
+      "Machine Learning Engineer、Data Scientist、Infrastructure Engineer、Platform Engineer などの職種を経験してきました。現在は株式会社エウレカにて Backend Engineer として、主に Go を用いた開発に携わっています。\n\n" +
+      "また、エウレカ以外では副業として、サービス立ち上げ当初からインフラ基盤をゼロから構築したり、TypeScript を用いたフルスタック開発にも取り組んでいます。",
+  },
+  experience: {
+    id: "experience",
+    heading: "Experience",
+    highlights: [
+      { year: "2025", text: "プロダクトの体験設計と実装を横断してリード" },
+      { year: "2024", text: "デザインシステム/コンポーネント整備で開発速度を改善" },
+      { year: "2023", text: "Next.js を中心にフロント基盤を刷新" },
+    ],
+  },
+  projects: {
+    id: "projects",
+    heading: "Projects",
+    items: [
+      {
+        visibility: "public",
+        title: "Retro Commerce",
+        summary: "NES感UIのEC体験。",
+        role: "Front-end",
+        tech: ["TypeScript", "Next.js", "Tailwind"],
+        outcomeOrLearning: "UIの一貫性と可読性を崩さずにスピードを出す型を作れた。",
+        link: { label: "Details", href: "#" },
+        status: "2024",
+      },
+      {
+        visibility: "public",
+        title: "Arcade CMS",
+        summary: "レトロテーマの管理画面。",
+        role: "Design Systems",
+        tech: ["React", "Component Design"],
+        outcomeOrLearning: "運用し続けられるコンポーネント粒度を学んだ。",
+        link: { label: "Details", href: "#" },
+        status: "2023",
+      },
+    ],
+  },
+  skills: {
+    id: "skills",
+    heading: "Skills",
+    items: [
+      { label: "TypeScript", level: 90 },
+      { label: "Next.js", level: 85 },
+      { label: "Design Systems", level: 80 },
+      { label: "Motion & Micro UX", level: 70 },
+    ],
+  },
+  contact: {
+    id: "contact",
+    heading: "Contact",
+    blurb: "お気軽にご連絡ください。",
+    links: [
+      { label: "Email", href: "worktkc2018@gmail.com" },
+      { label: "X / Twitter", href: "https://x.com/buzz_tkc" },
+      { label: "GitHub", href: "https://github.com/tkc66-buzz" },
+      { label: "LinkedIn", href: "https://www.linkedin.com/in/takeshi-watananbe-4736a8285/" },
+    ],
+  },
 };
 
-export const projects: SectionContent & { items: Project[] } = {
-  id: "projects",
-  heading: "Projects",
-  items: [
-    {
-      title: "Retro Commerce",
-      summary: "NES感UIのEC体験。",
-      role: "Front-end",
-      tech: ["TypeScript", "Next.js", "Tailwind"],
-      outcomeOrLearning: "UIの一貫性と可読性を崩さずにスピードを出す型を作れた。",
-      link: { label: "Details", href: "#" },
-      status: "2024",
-    },
-    {
-      title: "Arcade CMS",
-      summary: "レトロテーマの管理画面。",
-      role: "Design Systems",
-      tech: ["React", "Component Design"],
-      outcomeOrLearning: "運用し続けられるコンポーネント粒度を学んだ。",
-      link: { label: "Details", href: "#" },
-      status: "2023",
-    },
-  ],
-};
+function normalizeLinks(links: ExternalLink[]): ExternalLink[] {
+  return links.map((link) => {
+    if (link.label.toLowerCase() === "email" && !link.href.includes(":")) {
+      return { ...link, href: `mailto:${link.href}` };
+    }
+    return link;
+  });
+}
 
-export const skills: SectionContent & { items: Skill[] } = {
-  id: "skills",
-  heading: "Skills",
-  items: [
-    { label: "TypeScript", level: 90 },
-    { label: "Next.js", level: 85 },
-    { label: "Design Systems", level: 80 },
-    { label: "Motion & Micro UX", level: 70 },
-  ],
-};
+function mergePortfolio(base: Portfolio, patch: Partial<Portfolio>): Portfolio {
+  const merged: Portfolio = {
+    ...base,
+    ...patch,
+    profile: { ...base.profile, ...(patch.profile ?? {}) },
+    experience: { ...base.experience, ...(patch.experience ?? {}) },
+    projects: { ...base.projects, ...(patch.projects ?? {}) },
+    skills: { ...base.skills, ...(patch.skills ?? {}) },
+    contact: { ...base.contact, ...(patch.contact ?? {}) },
+  };
 
-export const contact: SectionContent & { blurb: string; links: ExternalLink[] } = {
-  id: "contact",
-  heading: "Contact",
-  blurb: "中身はあとで本番の連絡先に差し替えます。今は NES ボタンだけ配置。",
-  links: [
-    { label: "Email", href: "mailto:worktkc66@gmail.com" },
-    { label: "GitHub", href: "https://github.com/tkc66-buzz" },
-    { label: "X / Twitter", href: "https://x.com/buzz_tkc" },
-  ],
-};
+  merged.contact.links = normalizeLinks(merged.contact.links);
+  return merged;
+}
 
+async function loadPrivatePortfolioFromEnv(): Promise<Partial<Portfolio> | null> {
+  const raw = process.env.PORTFOLIO_PRIVATE_JSON;
+  if (!raw) return null;
+  return JSON.parse(raw) as Partial<Portfolio>;
+}
 
+async function loadPrivatePortfolioFromUrl(): Promise<Partial<Portfolio> | null> {
+  const url = process.env.PORTFOLIO_PRIVATE_URL;
+  if (!url) return null;
+
+  const token = process.env.PORTFOLIO_PRIVATE_URL_BEARER;
+  const revalidateSeconds = Number(process.env.PORTFOLIO_PRIVATE_REVALIDATE_SECONDS ?? "86400");
+  const revalidate = Number.isFinite(revalidateSeconds) ? Math.max(0, revalidateSeconds) : 86400;
+  const res = await fetch(url, {
+    headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+    // Cache private portfolio responses on the server to reduce load on the upstream.
+    // (Next.js fetch cache) default is cacheable; we set an explicit revalidate window.
+    next: { revalidate },
+  });
+
+  if (!res.ok) return null;
+  return (await res.json()) as Partial<Portfolio>;
+}
+
+/**
+ * Returns portfolio data with optional private overrides.
+ *
+ * Private data MUST NOT be committed to the repo. Provide it via either:
+ * - PORTFOLIO_PRIVATE_JSON (JSON string)
+ * - PORTFOLIO_PRIVATE_URL (+ optional PORTFOLIO_PRIVATE_URL_BEARER)
+ * - PORTFOLIO_PRIVATE_REVALIDATE_SECONDS (default: 86400)
+ */
+export async function getPortfolio(): Promise<Portfolio> {
+  const source = process.env.PORTFOLIO_PRIVATE_SOURCE; // "env" | "url" | undefined
+  try {
+    const patch =
+      source === "url"
+        ? await loadPrivatePortfolioFromUrl()
+        : source === "env"
+          ? await loadPrivatePortfolioFromEnv()
+          : await loadPrivatePortfolioFromEnv();
+    if (!patch) return mergePortfolio(publicPortfolio, {});
+    return mergePortfolio(publicPortfolio, patch);
+  } catch {
+    // Safety: never crash the site due to private data issues; fall back to public.
+    return mergePortfolio(publicPortfolio, {});
+  }
+}
+
+// Backwards-compatible named exports (public-only). Prefer getPortfolio().
+export const profile = publicPortfolio.profile;
+export const experience = publicPortfolio.experience;
+export const projects = publicPortfolio.projects;
+export const skills = publicPortfolio.skills;
+export const contact = publicPortfolio.contact;

--- a/src/content/portfolio.ts
+++ b/src/content/portfolio.ts
@@ -172,6 +172,17 @@ async function loadPrivatePortfolioFromUrl(): Promise<Partial<Portfolio> | null>
   const timeoutMs = Number(process.env.PORTFOLIO_PRIVATE_TIMEOUT_MS ?? "3000");
   const timeout = Number.isFinite(timeoutMs) ? Math.max(0, timeoutMs) : 3000;
 
+  const withQueryToken = (targetUrl: string) => {
+    if (!token) return targetUrl;
+    const u = new URL(targetUrl);
+    // Prefer query token for Apps Script endpoints, since Authorization headers are
+    // not reliably available to `doGet(e)` in Apps Script Web Apps.
+    if (u.hostname === "script.google.com" || u.hostname === "script.googleusercontent.com") {
+      u.searchParams.set("token", token);
+    }
+    return u.toString();
+  };
+
   const fetchWithAuth = async (targetUrl: string, signal: AbortSignal) => {
     return await fetch(targetUrl, {
       headers: token ? { Authorization: `Bearer ${token}` } : undefined,
@@ -192,7 +203,7 @@ async function loadPrivatePortfolioFromUrl(): Promise<Partial<Portfolio> | null>
   let res: Response | null = null;
   try {
     for (let i = 0; i < 3; i++) {
-      res = await fetchWithAuth(currentUrl, controller.signal);
+      res = await fetchWithAuth(withQueryToken(currentUrl), controller.signal);
       const isRedirect = res.status >= 300 && res.status < 400;
       if (!isRedirect) break;
       const location = res.headers.get("location");


### PR DESCRIPTION
This PR adds a safe way to maintain private Experience/Projects content outside the public GitHub repo, using Google Sheets + Apps Script as a JSON source. The site loads the overrides server-side only, caches them, and falls back to public content on failure.