### PR TITLE
003 skills categorization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ Unified cheat sheet so any AI agent (Claude Code, GPT, etc.) can understand the 
   for in-page anchor navigation.
 - Content data is centralized in `src/content/portfolio.ts` for maintainability.
   - Private overrides can be injected via env vars (no private content committed to git).
+  - Skills support both a flat list (`skills.items`) and categorized groups (`skills.categories`).
 
 ## Workflow Expectations
 - Branch from feature branch, open PR → merge to `main` → Vercel autodeploy.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,8 @@ Unified cheat sheet so any AI agent (Claude Code, GPT, etc.) can understand the 
   for in-page anchor navigation.
 - Content data is centralized in `src/content/portfolio.ts` for maintainability.
   - Private overrides can be injected via env vars (no private content committed to git).
-  - Skills support both a flat list (`skills.items`) and categorized groups (`skills.categories`).
+  - Skills support categorized groups (`skills.categories`) with a backward-compatible flat list (`skills.items`) derived from categories.
+    - Skills use `years` (required) and can optionally include `firstUsedYear` / `lastUsedYear` to show recency.
 
 ## Workflow Expectations
 - Branch from feature branch, open PR → merge to `main` → Vercel autodeploy.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ Focused tips for Anthropic Claude Code / Workbench agents interacting with this 
   - `PORTFOLIO_PRIVATE_URL` (+ optional `PORTFOLIO_PRIVATE_URL_BEARER`)
   - `PORTFOLIO_PRIVATE_REVALIDATE_SECONDS` (default 86400 = 24h cache)
   - `PORTFOLIO_PRIVATE_TIMEOUT_MS` (default 3000 = 3s timeout)
+  - Skills use `years` (required) and can optionally include `firstUsedYear` / `lastUsedYear` (numeric years) to show recency.
 - `src/app/layout.tsx` – Imports NES.css, fonts, metadata; extend when adding OG tags or global providers.
 - `tailwind.config.js` – Update `content` array if adding directories.
 - `postcss.config.js` – Standard pipeline; modify when adding plugins like `postcss-nesting`.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ When a change affects dependencies or workflows, remember to update README / doc
   - Projects can include `visibility: "public" | "private"`. Private items will be redacted
     on the public page (summary/outcome/link hidden).
     - With current UI, `visibility="private"` also hides role/tech/outcome/link (title + badges only).
+- Skills can be maintained either as a flat list (`skills.items`) or grouped by category
+  (`skills.categories`) for clearer storytelling.
 - Drop a `public/og.png` and extend `src/app/layout.tsx` metadata for richer previews.
 - Tweak NES colors or swap the background (`src/app/globals.css`) for other retro palettes.
 - Add new sections/components under `src/components` and include them via `@/` alias.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ When a change affects dependencies or workflows, remember to update README / doc
     - With current UI, `visibility="private"` also hides role/tech/outcome/link (title + badges only).
 - Skills can be maintained either as a flat list (`skills.items`) or grouped by category
   (`skills.categories`) for clearer storytelling.
-  - Prefer `years` (hands-on years) over subjective scores; legacy `level` is supported for backward compatibility.
+  - `years` (hands-on years) is required; subjective scoring is intentionally not used.
 - Drop a `public/og.png` and extend `src/app/layout.tsx` metadata for richer previews.
 - Tweak NES colors or swap the background (`src/app/globals.css`) for other retro palettes.
 - Add new sections/components under `src/components` and include them via `@/` alias.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ When a change affects dependencies or workflows, remember to update README / doc
     - With current UI, `visibility="private"` also hides role/tech/outcome/link (title + badges only).
 - Skills can be maintained either as a flat list (`skills.items`) or grouped by category
   (`skills.categories`) for clearer storytelling.
+  - Prefer `years` (hands-on years) over subjective scores; legacy `level` is supported for backward compatibility.
 - Drop a `public/og.png` and extend `src/app/layout.tsx` metadata for richer previews.
 - Tweak NES colors or swap the background (`src/app/globals.css`) for other retro palettes.
 - Add new sections/components under `src/components` and include them via `@/` alias.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ When a change affects dependencies or workflows, remember to update README / doc
 - Skills can be maintained either as a flat list (`skills.items`) or grouped by category
   (`skills.categories`) for clearer storytelling.
   - `years` (hands-on years) is required; subjective scoring is intentionally not used.
+  - Optionally add `firstUsedYear` / `lastUsedYear` (numeric years) to show recency vs past usage (e.g. `7y (2018–2024)`).
 - Drop a `public/og.png` and extend `src/app/layout.tsx` metadata for richer previews.
 - Tweak NES colors or swap the background (`src/app/globals.css`) for other retro palettes.
 - Add new sections/components under `src/components` and include them via `@/` alias.

--- a/src/components/sections/SkillsSection.tsx
+++ b/src/components/sections/SkillsSection.tsx
@@ -1,9 +1,28 @@
 import { getPortfolio } from "@/content/portfolio";
 
+function formatYears(years: number) {
+  if (Number.isInteger(years)) return `${years}y`;
+  return `${years}y`;
+}
+
+function skillValueYears(skill: { years?: number; level?: number }) {
+  if (typeof skill.years === "number") return skill.years;
+  return null;
+}
+
 export async function SkillsSection() {
   const { skills } = await getPortfolio();
   const categories =
     skills.categories && skills.categories.length > 0 ? skills.categories : null;
+
+  const allSkills = categories
+    ? categories.flatMap((c) => c.items)
+    : skills.items;
+  const yearValues = allSkills
+    .map((s) => skillValueYears(s))
+    .filter((v): v is number => typeof v === "number" && Number.isFinite(v) && v >= 0);
+  const maxYears = yearValues.length > 0 ? Math.max(...yearValues, 5) : 5;
+
   return (
     <section
       id={skills.id}
@@ -30,12 +49,16 @@ export async function SkillsSection() {
                   <div key={`${cat.name}:${skill.label}`}>
                     <div className="flex items-center justify-between text-xs uppercase tracking-[0.2em] text-fami-gold">
                       <span>{skill.label}</span>
-                      <span>{skill.level}%</span>
+                      <span className="normal-case">
+                        {skillValueYears(skill) !== null
+                          ? formatYears(skillValueYears(skill)!)
+                          : "—"}
+                      </span>
                     </div>
                     <progress
                       className="nes-progress is-warning"
-                      value={skill.level}
-                      max={100}
+                      value={skillValueYears(skill) ?? 0}
+                      max={maxYears}
                     />
                   </div>
                 ))}
@@ -49,12 +72,16 @@ export async function SkillsSection() {
             <div key={skill.label}>
               <div className="flex items-center justify-between text-xs uppercase tracking-[0.2em] text-fami-gold">
                 <span>{skill.label}</span>
-                <span>{skill.level}%</span>
+                <span className="normal-case">
+                  {skillValueYears(skill) !== null
+                    ? formatYears(skillValueYears(skill)!)
+                    : "—"}
+                </span>
               </div>
               <progress
                 className="nes-progress is-warning"
-                value={skill.level}
-                max={100}
+                value={skillValueYears(skill) ?? 0}
+                max={maxYears}
               />
             </div>
           ))}

--- a/src/components/sections/SkillsSection.tsx
+++ b/src/components/sections/SkillsSection.tsx
@@ -5,6 +5,16 @@ function formatYears(years: number) {
   return `${years}y`;
 }
 
+function formatUsageRange(skill: { firstUsedYear?: number; lastUsedYear?: number }) {
+  if (
+    typeof skill.firstUsedYear === "number" &&
+    typeof skill.lastUsedYear === "number"
+  ) {
+    return `${skill.firstUsedYear}–${skill.lastUsedYear}`;
+  }
+  return null;
+}
+
 export async function SkillsSection() {
   const { skills } = await getPortfolio();
   const categories =
@@ -46,6 +56,7 @@ export async function SkillsSection() {
                       <span>{skill.label}</span>
                       <span className="normal-case">
                         {formatYears(skill.years)}
+                        {formatUsageRange(skill) ? ` (${formatUsageRange(skill)})` : ""}
                       </span>
                     </div>
                     <progress
@@ -67,6 +78,7 @@ export async function SkillsSection() {
                 <span>{skill.label}</span>
                 <span className="normal-case">
                   {formatYears(skill.years)}
+                  {formatUsageRange(skill) ? ` (${formatUsageRange(skill)})` : ""}
                 </span>
               </div>
               <progress

--- a/src/components/sections/SkillsSection.tsx
+++ b/src/components/sections/SkillsSection.tsx
@@ -5,11 +5,6 @@ function formatYears(years: number) {
   return `${years}y`;
 }
 
-function skillValueYears(skill: { years?: number; level?: number }) {
-  if (typeof skill.years === "number") return skill.years;
-  return null;
-}
-
 export async function SkillsSection() {
   const { skills } = await getPortfolio();
   const categories =
@@ -19,7 +14,7 @@ export async function SkillsSection() {
     ? categories.flatMap((c) => c.items)
     : skills.items;
   const yearValues = allSkills
-    .map((s) => skillValueYears(s))
+    .map((s) => s.years)
     .filter((v): v is number => typeof v === "number" && Number.isFinite(v) && v >= 0);
   const maxYears = yearValues.length > 0 ? Math.max(...yearValues, 5) : 5;
 
@@ -50,14 +45,12 @@ export async function SkillsSection() {
                     <div className="flex items-center justify-between text-xs uppercase tracking-[0.2em] text-fami-gold">
                       <span>{skill.label}</span>
                       <span className="normal-case">
-                        {skillValueYears(skill) !== null
-                          ? formatYears(skillValueYears(skill)!)
-                          : "—"}
+                        {formatYears(skill.years)}
                       </span>
                     </div>
                     <progress
                       className="nes-progress is-warning"
-                      value={skillValueYears(skill) ?? 0}
+                      value={skill.years}
                       max={maxYears}
                     />
                   </div>
@@ -73,14 +66,12 @@ export async function SkillsSection() {
               <div className="flex items-center justify-between text-xs uppercase tracking-[0.2em] text-fami-gold">
                 <span>{skill.label}</span>
                 <span className="normal-case">
-                  {skillValueYears(skill) !== null
-                    ? formatYears(skillValueYears(skill)!)
-                    : "—"}
+                  {formatYears(skill.years)}
                 </span>
               </div>
               <progress
                 className="nes-progress is-warning"
-                value={skillValueYears(skill) ?? 0}
+                value={skill.years}
                 max={maxYears}
               />
             </div>

--- a/src/components/sections/SkillsSection.tsx
+++ b/src/components/sections/SkillsSection.tsx
@@ -2,6 +2,8 @@ import { getPortfolio } from "@/content/portfolio";
 
 export async function SkillsSection() {
   const { skills } = await getPortfolio();
+  const categories =
+    skills.categories && skills.categories.length > 0 ? skills.categories : null;
   return (
     <section
       id={skills.id}
@@ -13,21 +15,51 @@ export async function SkillsSection() {
       >
         {skills.heading}
       </h2>
-      <div className="mt-3 space-y-4">
-        {skills.items.map((skill) => (
-          <div key={skill.label}>
-            <div className="flex items-center justify-between text-xs uppercase tracking-[0.2em] text-fami-gold">
-              <span>{skill.label}</span>
-              <span>{skill.level}%</span>
+      {categories ? (
+        <div className="mt-4 space-y-6">
+          {categories.map((cat) => (
+            <div key={cat.name}>
+              <h3
+                className="text-xs uppercase tracking-[0.3em] text-fami-gold"
+                style={{ fontFamily: "var(--font-press)" }}
+              >
+                {cat.name}
+              </h3>
+              <div className="mt-3 space-y-4">
+                {cat.items.map((skill) => (
+                  <div key={`${cat.name}:${skill.label}`}>
+                    <div className="flex items-center justify-between text-xs uppercase tracking-[0.2em] text-fami-gold">
+                      <span>{skill.label}</span>
+                      <span>{skill.level}%</span>
+                    </div>
+                    <progress
+                      className="nes-progress is-warning"
+                      value={skill.level}
+                      max={100}
+                    />
+                  </div>
+                ))}
+              </div>
             </div>
-            <progress
-              className="nes-progress is-warning"
-              value={skill.level}
-              max={100}
-            />
-          </div>
-        ))}
-      </div>
+          ))}
+        </div>
+      ) : (
+        <div className="mt-3 space-y-4">
+          {skills.items.map((skill) => (
+            <div key={skill.label}>
+              <div className="flex items-center justify-between text-xs uppercase tracking-[0.2em] text-fami-gold">
+                <span>{skill.label}</span>
+                <span>{skill.level}%</span>
+              </div>
+              <progress
+                className="nes-progress is-warning"
+                value={skill.level}
+                max={100}
+              />
+            </div>
+          ))}
+        </div>
+      )}
     </section>
   );
 }

--- a/src/content/portfolio.ts
+++ b/src/content/portfolio.ts
@@ -116,29 +116,34 @@ export const publicPortfolio: Portfolio = {
       { label: "Go", years: 3 },
       { label: "TypeScript", years: 3 },
       { label: "AWS", years: 3 },
-      { label: "GCP", years: 2 },
+      { label: "Terraform", years: 3 },
+      { label: "Observability", years: 4 },
     ],
     categories: [
       {
-        name: "Backend",
+        name: "Backend (Go / TypeScript)",
         items: [
           { label: "Go", years: 3 },
+          { label: "TypeScript", years: 3 },
           { label: "API Design", years: 4 },
           { label: "SQL / Data modeling", years: 4 },
+          { label: "Performance / Profiling", years: 3 },
         ],
       },
       {
         name: "Infrastructure",
         items: [
           { label: "AWS", years: 3 },
+          { label: "GCP", years: 2 },
           { label: "Terraform", years: 3 },
           { label: "Observability", years: 4 },
+          { label: "CI/CD", years: 3 },
         ],
       },
       {
         name: "Data / ML",
         items: [
-          { label: "Data Science", years: 2 },
+          { label: "Data Analysis", years: 2 },
           { label: "ML Engineering", years: 2 },
         ],
       },

--- a/src/content/portfolio.ts
+++ b/src/content/portfolio.ts
@@ -4,6 +4,8 @@ import { unstable_cache } from "next/cache";
 
 import type { TocItemId } from "@/components/toc";
 
+const CURRENT_YEAR = new Date().getFullYear();
+
 export type ExternalLink = {
   label: string;
   href: string;
@@ -70,6 +72,23 @@ export type Portfolio = {
   skills: Skills;
   contact: Contact;
 };
+
+function yearsFromRangeInclusive(firstUsedYear: number, lastUsedYear: number): number {
+  return Math.max(0, lastUsedYear - firstUsedYear + 1);
+}
+
+function skillRange(
+  label: string,
+  firstUsedYear: number,
+  lastUsedYear: number,
+): Skill {
+  return {
+    label,
+    years: yearsFromRangeInclusive(firstUsedYear, lastUsedYear),
+    firstUsedYear,
+    lastUsedYear,
+  };
+}
 
 function flattenSkillCategories(categories: SkillCategory[]): Skill[] {
   const byLabel = new Map<string, Skill>();
@@ -141,34 +160,34 @@ export const publicPortfolio: Portfolio = {
       {
         name: "Backend (Go / TypeScript)",
         items: [
-          { label: "Go", years: 3 },
-          { label: "TypeScript", years: 3 },
-          { label: "API Design", years: 7 },
-          { label: "SQL / Data modeling", years: 7 },
+          skillRange("Go", 2022, CURRENT_YEAR),
+          skillRange("TypeScript", 2023, CURRENT_YEAR),
+          skillRange("API Design", 2019, CURRENT_YEAR),
+          skillRange("RDB / NoSQL", 2019, CURRENT_YEAR),
         ],
       },
       {
         name: "Infrastructure",
         items: [
-          { label: "AWS", years: 8 },
-          { label: "Google Cloud Platform", years: 3 },
-          { label: "Terraform", years: 4 },
-          { label: "Observability", years: 5 },
-          { label: "CI/CD", years: 7 },
+          skillRange("AWS", 2019, CURRENT_YEAR),
+          skillRange("GCP", 2022, CURRENT_YEAR),
+          skillRange("Terraform", 2021, CURRENT_YEAR),
+          skillRange("Observability (Datadog)", 2019, CURRENT_YEAR),
+          skillRange("CI/CD", 2019, CURRENT_YEAR),
         ],
       },
       {
         name: "Data / ML",
         items: [
-          { label: "Data Analysis", years: 3 },
-          { label: "ML Engineering", years: 3 },
+          skillRange("Data Analysis", 2019, 2022),
+          skillRange("ML Engineering", 2019, 2022),
         ],
       },
       {
         name: "Frontend",
         items: [
-          { label: "TypeScript", years: 3 },
-          { label: "React", years: 3 },
+          skillRange("TypeScript", 2023, CURRENT_YEAR),
+          skillRange("React", 2023, CURRENT_YEAR),
         ],
       },
     ],

--- a/src/content/portfolio.ts
+++ b/src/content/portfolio.ts
@@ -32,6 +32,11 @@ export type Skill = {
   level: number;
 };
 
+export type SkillCategory = {
+  name: string;
+  items: Skill[];
+};
+
 export type SectionContent = {
   id: TocItemId;
   heading: string;
@@ -40,7 +45,7 @@ export type SectionContent = {
 export type Profile = SectionContent & { body: string };
 export type Experience = SectionContent & { highlights: ExperienceHighlight[] };
 export type Projects = SectionContent & { items: Project[] };
-export type Skills = SectionContent & { items: Skill[] };
+export type Skills = SectionContent & { items: Skill[]; categories?: SkillCategory[] };
 export type Contact = SectionContent & { blurb: string; links: ExternalLink[] };
 
 export type Portfolio = {
@@ -97,11 +102,45 @@ export const publicPortfolio: Portfolio = {
   skills: {
     id: "skills",
     heading: "Skills",
+    // Backward compatible: `items` can still be used by external overrides.
     items: [
-      { label: "TypeScript", level: 90 },
-      { label: "Next.js", level: 85 },
-      { label: "Design Systems", level: 80 },
-      { label: "Motion & Micro UX", level: 70 },
+      { label: "Go", level: 85 },
+      { label: "TypeScript", level: 85 },
+      { label: "AWS", level: 75 },
+      { label: "GCP", level: 70 },
+    ],
+    categories: [
+      {
+        name: "Backend",
+        items: [
+          { label: "Go", level: 85 },
+          { label: "API Design", level: 80 },
+          { label: "SQL / Data modeling", level: 75 },
+        ],
+      },
+      {
+        name: "Infrastructure",
+        items: [
+          { label: "AWS", level: 75 },
+          { label: "Terraform", level: 70 },
+          { label: "Observability", level: 70 },
+        ],
+      },
+      {
+        name: "Data / ML",
+        items: [
+          { label: "Data Science", level: 70 },
+          { label: "ML Engineering", level: 65 },
+        ],
+      },
+      {
+        name: "Frontend",
+        items: [
+          { label: "TypeScript", level: 85 },
+          { label: "React / Next.js", level: 75 },
+          { label: "Design Systems", level: 70 },
+        ],
+      },
     ],
   },
   contact: {

--- a/src/content/portfolio.ts
+++ b/src/content/portfolio.ts
@@ -34,6 +34,17 @@ export type Skill = {
    * Use integer or half steps (e.g. 3.5).
    */
   years: number;
+  /**
+   * First year you used this skill in practice (optional).
+   * If set, `lastUsedYear` must also be set.
+   */
+  firstUsedYear?: number;
+  /**
+   * Last year you used this skill in practice (optional).
+   * Use the current year if you still use it.
+   * If set, `firstUsedYear` must also be set.
+   */
+  lastUsedYear?: number;
 };
 
 export type SkillCategory = {
@@ -132,34 +143,32 @@ export const publicPortfolio: Portfolio = {
         items: [
           { label: "Go", years: 3 },
           { label: "TypeScript", years: 3 },
-          { label: "API Design", years: 4 },
-          { label: "SQL / Data modeling", years: 4 },
-          { label: "Performance / Profiling", years: 3 },
+          { label: "API Design", years: 7 },
+          { label: "SQL / Data modeling", years: 7 },
         ],
       },
       {
         name: "Infrastructure",
         items: [
           { label: "AWS", years: 8 },
-          { label: "GCP", years: 2 },
+          { label: "Google Cloud Platform", years: 3 },
           { label: "Terraform", years: 4 },
           { label: "Observability", years: 5 },
-          { label: "CI/CD", years: 3 },
+          { label: "CI/CD", years: 7 },
         ],
       },
       {
         name: "Data / ML",
         items: [
-          { label: "Data Analysis", years: 2 },
-          { label: "ML Engineering", years: 2 },
+          { label: "Data Analysis", years: 3 },
+          { label: "ML Engineering", years: 3 },
         ],
       },
       {
         name: "Frontend",
         items: [
           { label: "TypeScript", years: 3 },
-          { label: "React / Next.js", years: 3 },
-          { label: "Design Systems", years: 3 },
+          { label: "React", years: 3 },
         ],
       },
     ],
@@ -229,7 +238,20 @@ function validateSkills(skills: Skills): boolean {
   const isValidYears = (y: unknown) =>
     typeof y === "number" && Number.isFinite(y) && y >= 0;
 
-  const validateItems = (items: Skill[]) => items.every((s) => isValidYears(s.years));
+  const isValidUsageYear = (y: unknown) =>
+    typeof y === "number" && Number.isInteger(y) && y >= 1970 && y <= 2100;
+
+  const validateUsageRange = (s: Skill) => {
+    const hasFirst = typeof s.firstUsedYear !== "undefined";
+    const hasLast = typeof s.lastUsedYear !== "undefined";
+    if (hasFirst !== hasLast) return false;
+    if (!hasFirst) return true;
+    if (!isValidUsageYear(s.firstUsedYear) || !isValidUsageYear(s.lastUsedYear)) return false;
+    return (s.firstUsedYear as number) <= (s.lastUsedYear as number);
+  };
+
+  const validateItems = (items: Skill[]) =>
+    items.every((s) => isValidYears(s.years) && validateUsageRange(s));
 
   if (!validateItems(skills.items)) return false;
   if (!skills.categories) return true;

--- a/src/content/portfolio.ts
+++ b/src/content/portfolio.ts
@@ -158,10 +158,11 @@ export const publicPortfolio: Portfolio = {
     items: [],
     categories: [
       {
-        name: "Backend (Go / TypeScript)",
+        name: "Backend",
         items: [
           skillRange("Go", 2022, CURRENT_YEAR),
           skillRange("TypeScript", 2023, CURRENT_YEAR),
+          skillRange("Python", 2019, 2022),
           skillRange("API Design", 2019, CURRENT_YEAR),
           skillRange("RDB / NoSQL", 2019, CURRENT_YEAR),
         ],

--- a/src/content/portfolio.ts
+++ b/src/content/portfolio.ts
@@ -29,7 +29,16 @@ export type ExperienceHighlight = {
 
 export type Skill = {
   label: string;
-  level: number;
+  /**
+   * Years of hands-on experience (preferred).
+   * Use integer or half steps (e.g. 3.5).
+   */
+  years?: number;
+  /**
+   * Legacy subjective score (0-100). Kept for backward compatibility with older data.
+   * Prefer `years`.
+   */
+  level?: number;
 };
 
 export type SkillCategory = {
@@ -104,41 +113,41 @@ export const publicPortfolio: Portfolio = {
     heading: "Skills",
     // Backward compatible: `items` can still be used by external overrides.
     items: [
-      { label: "Go", level: 85 },
-      { label: "TypeScript", level: 85 },
-      { label: "AWS", level: 75 },
-      { label: "GCP", level: 70 },
+      { label: "Go", years: 3 },
+      { label: "TypeScript", years: 3 },
+      { label: "AWS", years: 3 },
+      { label: "GCP", years: 2 },
     ],
     categories: [
       {
         name: "Backend",
         items: [
-          { label: "Go", level: 85 },
-          { label: "API Design", level: 80 },
-          { label: "SQL / Data modeling", level: 75 },
+          { label: "Go", years: 3 },
+          { label: "API Design", years: 4 },
+          { label: "SQL / Data modeling", years: 4 },
         ],
       },
       {
         name: "Infrastructure",
         items: [
-          { label: "AWS", level: 75 },
-          { label: "Terraform", level: 70 },
-          { label: "Observability", level: 70 },
+          { label: "AWS", years: 3 },
+          { label: "Terraform", years: 3 },
+          { label: "Observability", years: 4 },
         ],
       },
       {
         name: "Data / ML",
         items: [
-          { label: "Data Science", level: 70 },
-          { label: "ML Engineering", level: 65 },
+          { label: "Data Science", years: 2 },
+          { label: "ML Engineering", years: 2 },
         ],
       },
       {
         name: "Frontend",
         items: [
-          { label: "TypeScript", level: 85 },
-          { label: "React / Next.js", level: 75 },
-          { label: "Design Systems", level: 70 },
+          { label: "TypeScript", years: 3 },
+          { label: "React / Next.js", years: 3 },
+          { label: "Design Systems", years: 3 },
         ],
       },
     ],


### PR DESCRIPTION
目的
Skills の主観スコアをやめ、経験年数（years）と利用期間（first/last year）で「強み」と「直近触っているか」を正確に伝える。
変更内容
Skillsを年数ベースに変更
Skill.years を必須化（曖昧表示なし）
利用期間の追加
Skill.firstUsedYear / Skill.lastUsedYear を追加（数値年のみ、片方だけは不許可）
UIで 7y (2019–2025) のように表示
二重定義の解消
skills.categories を単一ソースにし、skills.items は categories から自動生成（後方互換のみ）
Skillsデータの確定入力
Go/TS/API/DB/AWS/GCP/Terraform/Datadog/CI/CD/Data/ML/React/Python などのレンジを反映（~ は 2025 扱い）
