### PR TITLE
004 content public story

### DIFF
--- a/specs/004-content-public-story/contracts/README.md
+++ b/specs/004-content-public-story/contracts/README.md
@@ -1,0 +1,7 @@
+# Contracts
+
+This feature is content-only and does not introduce new external APIs.
+
+- **Contracts**: N/A
+
+

--- a/specs/004-content-public-story/data-model.md
+++ b/specs/004-content-public-story/data-model.md
@@ -1,0 +1,57 @@
+# Data Model: Phase 2 Content – Public Storytelling
+
+## Overview
+
+This feature is content-focused. It primarily updates text and presentation while preserving:
+- server-side private overrides (`PORTFOLIO_PRIVATE_*`)
+- redaction behavior for `Project.visibility="private"`
+
+## Entities
+
+### Portfolio (existing)
+
+- **profile**: unchanged
+- **experience**: may be enriched but must remain backward compatible
+- **projects**: unchanged shape, content updated
+- **skills**: unchanged for this feature
+- **contact**: copy/CTA updated
+
+### Experience (current)
+
+```ts
+type ExperienceHighlight = { year: string; text: string };
+type Experience = SectionContent & { highlights: ExperienceHighlight[] };
+```
+
+**Notes**
+- If richer “timeframe/role” is desired later, add optional fields (not required for this feature).
+
+### Project (current)
+
+```ts
+type Project = {
+  visibility?: "public" | "private";
+  title: string;
+  summary: string;
+  role: string;
+  tech: string[];
+  outcomeOrLearning: string;
+  link?: ExternalLink;
+  status?: string;
+};
+```
+
+**Validation / Rules**
+- For public projects, all proof fields should be present.
+- For private projects, the UI must redact sensitive fields (already implemented).
+
+### Contact (current)
+
+```ts
+type Contact = SectionContent & { blurb: string; links: ExternalLink[] };
+```
+
+**Rules**
+- `blurb` should include CTA examples (what to contact about) and response expectation.
+
+

--- a/specs/004-content-public-story/plan.md
+++ b/specs/004-content-public-story/plan.md
@@ -3,47 +3,66 @@
 **Branch**: `004-content-public-story` | **Date**: 2025-12-25 | **Spec**: `specs/004-content-public-story/spec.md`
 **Input**: Feature specification from `specs/004-content-public-story/spec.md`
 
-**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/commands/plan.md` for the execution workflow.
-
 ## Summary
 
-Public-facing content for Experience/Projects/Contact is upgraded from scaffolding to a cohesive narrative.
-The implementation keeps privacy guarantees (private overrides + redaction) while improving scan-ability and
-clarity so a first-time visitor understands the owner in <2 minutes.
+Replace scaffolding/placeholder-ish copy with a cohesive public narrative for:
+- Experience (proof of responsibility + outcomes)
+- Projects (scan-able cards that “prove” skill/impact)
+- Contact (clear CTA: what to reach out about, response expectation)
+
+All changes must preserve privacy guarantees: public-only must read well, private overrides remain optional, and `visibility="private"` redaction continues to prevent leaks.
 
 ## Technical Context
-
-<!--
-  ACTION REQUIRED: Replace the content in this section with the technical details
-  for the project. The structure here is presented in advisory capacity to guide
-  the iteration process.
--->
 
 **Language/Version**: TypeScript 5.x (Next.js 16 App Router)  
 **Primary Dependencies**: Next.js, React 19, Tailwind CSS, NES.css  
 **Storage**: N/A (static content) + optional private override via env/url (server-side fetch)  
-**Testing**: No automated tests (quality gates are `pnpm lint` + `pnpm build`)  
-**Target Platform**: Vercel (static/SSR)  
+**Testing**: No automated tests; quality gates are `pnpm lint` + `pnpm build`  
+**Target Platform**: Vercel  
 **Project Type**: Web application (single-page portfolio)  
-**Performance Goals**: Keep bundle lean; avoid new deps; fast mobile render  
-**Constraints**: Must not leak private content; public-only must read well; keep UX retro-but-usable  
-**Scale/Scope**: Small content-focused change across sections + `src/content/portfolio.ts`
+**Performance Goals**: Keep it lightweight; no new runtime deps  
+**Constraints**: Must not leak private content; public-only must be coherent; maintain retro aesthetic + usability  
+**Scale/Scope**: Update copy in `src/content/portfolio.ts` and presentation in section components as needed
 
 ## Constitution Check
 
 *GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
 
-Use `.specify/memory/constitution.md` as the source of truth. This repo’s default
-gates (adapt per feature) are:
+- Principle compliance: Improves “Personality-First Storytelling” by replacing filler with evidence-backed narrative.
+- Retro aesthetic + usability: Keep hierarchy clear and scan-friendly; don’t over-style.
+- Quality gates: `pnpm lint` and `pnpm build` must pass.
+- Docs sync: No dependency/workflow changes expected; if we change top-level UX significantly, sync docs.
 
-- Principle compliance: changes support “Personality-First Storytelling” and do not
-  dilute the retro aesthetic + usability balance.
-- Quality gates: `pnpm lint` and `pnpm build` pass.
-- Docs sync: if dependencies/scripts/runtime/deploy/top-level UX change, update
-  `README.md`, `AGENTS.md`, and `CLAUDE.md` together.
+**Gate Result (pre-research)**: PASS
 
-**Gate Result (pre-research)**: PASS  
-- The work is explicitly about replacing scaffolding with real narrative and preserving privacy.
+## Phase 0: Outline & Research
+
+**Unknowns (resolved in `research.md`)**
+- Public-safe “proof set” and phrasing patterns under NDA constraints
+- How to state impact without leaking sensitive numbers
+- CTA structure that increases qualified inbound
+
+**Output**: `specs/004-content-public-story/research.md`
+
+## Phase 1: Design & Contracts
+
+### Data model decision
+
+- Keep current `Portfolio` shape.
+- Prefer content updates over schema changes.
+- If we add richer Experience fields later, keep them optional and validate (not required for this feature).
+
+**Output**: `specs/004-content-public-story/data-model.md`
+
+### Contracts
+
+No new external APIs introduced for this feature.  
+**Output**: `specs/004-content-public-story/contracts/README.md` (N/A)
+
+### Quickstart
+
+Validation steps for public-only vs private override + redaction.  
+**Output**: `specs/004-content-public-story/quickstart.md`
 
 ## Project Structure
 
@@ -51,27 +70,21 @@ gates (adapt per feature) are:
 
 ```text
 specs/004-content-public-story/
-├── plan.md              # This file (/speckit.plan command output)
-├── research.md          # Phase 0 output (/speckit.plan command)
-├── data-model.md        # Phase 1 output (/speckit.plan command)
-├── quickstart.md        # Phase 1 output (/speckit.plan command)
-├── contracts/           # Phase 1 output (/speckit.plan command)
-└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── README.md
+└── tasks.md             # created by /speckit.tasks (next step)
 ```
 
 ### Source Code (repository root)
-<!--
-  ACTION REQUIRED: Replace the placeholder tree below with the concrete layout
-  for this feature. Delete unused options and expand the chosen structure with
-  real paths (e.g., apps/admin, packages/something). The delivered plan must
-  not include Option labels.
--->
 
 ```text
 src/
 ├── app/
-│   ├── page.tsx
-│   └── globals.css
+│   └── page.tsx
 ├── components/
 │   └── sections/
 │       ├── ExperienceSection.tsx
@@ -81,41 +94,8 @@ src/
     └── portfolio.ts
 ```
 
-**Structure Decision**: Update copy in `src/content/portfolio.ts` and adjust presentation in
-`src/components/sections/*` as needed. No new routes or services.
-
-## Phase 0: Outline & Research
-
-### Unknowns / NEEDS CLARIFICATION
-
-- What public-safe “proof set” is acceptable for Experience/Projects (what can be said without NDA risk)?
-- How should we express quantitative impact when numbers are sensitive (approved phrasing patterns)?
-- What CTA variants best match desired inbound (job / side work / consulting / tech talk)?
-
-## Phase 0 Output: research.md
-
-See `specs/004-content-public-story/research.md`.
-
-## Phase 1: Design & Contracts
-
-### Data Model
-
-- We keep the existing `Portfolio` types; additions must not break private overrides.
-- If we add fields (e.g., experience role/company/timeframe), they must be optional and validated.
-
-### Contracts
-
-- No external API contracts for this feature (content-only). Keep `contracts/README.md` stating N/A.
+**Structure Decision**: Keep `page.tsx` thin, put story content in `src/content/portfolio.ts`, and adjust section UI only to improve readability/scan-ability.
 
 ## Re-check Constitution (post-design)
 
-**Gate Result (post-design)**: PASS (expected)
-
-## Complexity Tracking
-
-> **Fill ONLY if Constitution Check has violations that must be justified**
-
-| Violation | Why Needed | Simpler Alternative Rejected Because |
-|-----------|------------|-------------------------------------|
-| [e.g., 4th project] | [current need] | [why 3 projects insufficient] |
-| [e.g., Repository pattern] | [specific problem] | [why direct DB access insufficient] |
+**Gate Result (post-design)**: PASS (expected; content-only feature)

--- a/specs/004-content-public-story/plan.md
+++ b/specs/004-content-public-story/plan.md
@@ -1,0 +1,121 @@
+# Implementation Plan: Phase 2 Content – Public Storytelling (Experience/Projects/Contact)
+
+**Branch**: `004-content-public-story` | **Date**: 2025-12-25 | **Spec**: `specs/004-content-public-story/spec.md`
+**Input**: Feature specification from `specs/004-content-public-story/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/commands/plan.md` for the execution workflow.
+
+## Summary
+
+Public-facing content for Experience/Projects/Contact is upgraded from scaffolding to a cohesive narrative.
+The implementation keeps privacy guarantees (private overrides + redaction) while improving scan-ability and
+clarity so a first-time visitor understands the owner in <2 minutes.
+
+## Technical Context
+
+<!--
+  ACTION REQUIRED: Replace the content in this section with the technical details
+  for the project. The structure here is presented in advisory capacity to guide
+  the iteration process.
+-->
+
+**Language/Version**: TypeScript 5.x (Next.js 16 App Router)  
+**Primary Dependencies**: Next.js, React 19, Tailwind CSS, NES.css  
+**Storage**: N/A (static content) + optional private override via env/url (server-side fetch)  
+**Testing**: No automated tests (quality gates are `pnpm lint` + `pnpm build`)  
+**Target Platform**: Vercel (static/SSR)  
+**Project Type**: Web application (single-page portfolio)  
+**Performance Goals**: Keep bundle lean; avoid new deps; fast mobile render  
+**Constraints**: Must not leak private content; public-only must read well; keep UX retro-but-usable  
+**Scale/Scope**: Small content-focused change across sections + `src/content/portfolio.ts`
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Use `.specify/memory/constitution.md` as the source of truth. This repo’s default
+gates (adapt per feature) are:
+
+- Principle compliance: changes support “Personality-First Storytelling” and do not
+  dilute the retro aesthetic + usability balance.
+- Quality gates: `pnpm lint` and `pnpm build` pass.
+- Docs sync: if dependencies/scripts/runtime/deploy/top-level UX change, update
+  `README.md`, `AGENTS.md`, and `CLAUDE.md` together.
+
+**Gate Result (pre-research)**: PASS  
+- The work is explicitly about replacing scaffolding with real narrative and preserving privacy.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/004-content-public-story/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+<!--
+  ACTION REQUIRED: Replace the placeholder tree below with the concrete layout
+  for this feature. Delete unused options and expand the chosen structure with
+  real paths (e.g., apps/admin, packages/something). The delivered plan must
+  not include Option labels.
+-->
+
+```text
+src/
+├── app/
+│   ├── page.tsx
+│   └── globals.css
+├── components/
+│   └── sections/
+│       ├── ExperienceSection.tsx
+│       ├── ProjectsSection.tsx
+│       └── ContactSection.tsx
+└── content/
+    └── portfolio.ts
+```
+
+**Structure Decision**: Update copy in `src/content/portfolio.ts` and adjust presentation in
+`src/components/sections/*` as needed. No new routes or services.
+
+## Phase 0: Outline & Research
+
+### Unknowns / NEEDS CLARIFICATION
+
+- What public-safe “proof set” is acceptable for Experience/Projects (what can be said without NDA risk)?
+- How should we express quantitative impact when numbers are sensitive (approved phrasing patterns)?
+- What CTA variants best match desired inbound (job / side work / consulting / tech talk)?
+
+## Phase 0 Output: research.md
+
+See `specs/004-content-public-story/research.md`.
+
+## Phase 1: Design & Contracts
+
+### Data Model
+
+- We keep the existing `Portfolio` types; additions must not break private overrides.
+- If we add fields (e.g., experience role/company/timeframe), they must be optional and validated.
+
+### Contracts
+
+- No external API contracts for this feature (content-only). Keep `contracts/README.md` stating N/A.
+
+## Re-check Constitution (post-design)
+
+**Gate Result (post-design)**: PASS (expected)
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| [e.g., 4th project] | [current need] | [why 3 projects insufficient] |
+| [e.g., Repository pattern] | [specific problem] | [why direct DB access insufficient] |

--- a/specs/004-content-public-story/quickstart.md
+++ b/specs/004-content-public-story/quickstart.md
@@ -1,0 +1,31 @@
+# Quickstart: Phase 2 Content – Public Storytelling
+
+## Goal
+
+Verify that the public portfolio reads as a coherent narrative (no placeholders) and remains safe with private overrides.
+
+## Setup
+
+```bash
+cd /Users/takeshiwatanabe/EureWorks/private/git/portfolio
+pnpm install
+pnpm dev
+```
+
+Open `http://localhost:3000`.
+
+## Verification checklist
+
+1. **Public-only reads well**
+   - Temporarily disable private overrides (`PORTFOLIO_PRIVATE_SOURCE` unset) and refresh.
+   - Confirm Experience/Projects/Contact are still coherent and not placeholder text.
+2. **Private override does not break public**
+   - Re-enable private overrides (`PORTFOLIO_PRIVATE_SOURCE=url` or `env`) and refresh.
+   - Confirm the page renders without errors.
+3. **Private project redaction**
+   - Ensure at least one `visibility="private"` project exists in override.
+   - Confirm sensitive fields are not shown on the public page.
+4. **Quality gates**
+   - Run `pnpm lint` and `pnpm build` successfully.
+
+

--- a/specs/004-content-public-story/quickstart.md
+++ b/specs/004-content-public-story/quickstart.md
@@ -28,4 +28,10 @@ Open `http://localhost:3000`.
 4. **Quality gates**
    - Run `pnpm lint` and `pnpm build` successfully.
 
+## Definition of Done (quick)
+
+- Public-only (no private overrides) still reads as a complete narrative (no placeholder-ish copy).
+- With private overrides enabled, the page still renders and private projects remain redacted.
+- Contact includes explicit CTA examples + response expectation.
+
 

--- a/specs/004-content-public-story/research.md
+++ b/specs/004-content-public-story/research.md
@@ -1,0 +1,33 @@
+# Research: Phase 2 Content – Public Storytelling
+
+## Decision 1: Public-safe proof set for Experience/Projects
+
+- **Decision**: Use a “proof set” that avoids identifiers but keeps evidence:
+  - Scope (traffic, scale, team size) as ranges (e.g., “daily active users: 7-figure range”) ONLY if approved; otherwise qualitative.
+  - Role + responsibilities (what you owned).
+  - Outcome/learning framed as capability (e.g., “reduced operational toil”, “improved release confidence”).
+- **Rationale**: Preserves NDA/privacy while still demonstrating seniority and impact.
+- **Alternatives considered**:
+  - Full disclosure with names/numbers → rejected (privacy/NDA risk).
+  - Vague claims without evidence → rejected (weak credibility).
+
+## Decision 2: Quantitative impact when numbers are sensitive
+
+- **Decision**: Prefer one of:
+  - Exact numbers when public/approved.
+  - Ranges (“~”, “approx.” avoided on page; use “X–Y” bands).
+  - Proxy metrics (latency p95 improvement, incident count, lead time).
+  - “Before/after” with relative terms (“significantly”, “materially”) ONLY if accompanied by mechanism (what changed).
+- **Rationale**: Keeps statements defensible and non-hand-wavy.
+- **Alternatives considered**:
+  - Always show exact numbers → rejected (often sensitive).
+  - Always avoid metrics → rejected (reduces proof).
+
+## Decision 3: Contact CTA shape
+
+- **Decision**: Provide a short list of “good inbound” examples (3–5 bullets) and a response-time expectation.
+- **Rationale**: Reduces friction, increases qualified inbound.
+- **Alternatives considered**:
+  - Generic “お気軽に” only → rejected (low intent, unclear).
+
+

--- a/specs/004-content-public-story/research.md
+++ b/specs/004-content-public-story/research.md
@@ -30,4 +30,15 @@
 - **Alternatives considered**:
   - Generic “お気軽に” only → rejected (low intent, unclear).
 
+## Public-proof writing checklist (NDA-safe)
+
+Use this checklist when editing `src/content/portfolio.ts` (Experience/Projects/Contact):
+
+- **No identifiers**: avoid internal project names, private URLs, customer names, unreleased features.
+- **Evidence over adjectives**: replace “頑張った/改善した” with mechanism + outcome.
+- **Impact without leakage**: prefer safe bands (`X–Y`) or proxy metrics (p95 latency, incident count, lead time).
+- **Role clarity**: state what you owned (design / implementation / ops / leadership).
+- **Scan-first**: each project must communicate `role + tech + outcome` in one card.
+- **Private items**: show only safe meta + “話せる範囲” guidance; never include sensitive details.
+
 

--- a/specs/004-content-public-story/spec.md
+++ b/specs/004-content-public-story/spec.md
@@ -1,0 +1,84 @@
+# Feature Specification: Phase 2 Content – Public Storytelling (Experience/Projects/Contact)
+
+**Feature Branch**: `004-content-public-story`  
+**Created**: 2025-12-25  
+**Status**: Draft  
+**Input**: User description: "003はmergeした。次はExperience/Projects/Contactの公開向けコンテンツを完成させたい（Privateは外部データ運用）。"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - 初見で「何ができる人か」が2分で伝わる (Priority: P1)
+
+採用/協業の初見ユーザーとして、スクロールしながら短時間で「強み・実績・仕事の進め方」を把握したい。
+
+**Why this priority**: ポートフォリオの第一目的（理解/判断）に直結するため。
+
+**Independent Test**: 初見の第三者が `Profile → Experience → Projects → Skills` を順に読んで、要約（強み/証拠/価値）を説明できる。
+
+**Acceptance Scenarios**:
+
+1. **Given** ページを開く、**When** Profile/Experience/Projects を読む、**Then** 強みが具体的な証拠（成果/役割/規模感）と一緒に提示される
+2. **Given** Projects を開く、**When** 各カードを見る、**Then** 役割/技術/成果(または学び)が1カード内で完結する
+
+---
+
+### User Story 2 - 守秘しながらも価値が伝わる (Priority: P2)
+
+サイトオーナーとして、NDA等で公開できない情報は外部データやredactionで守りつつ、公開ページだけでも価値が伝わる見せ方にしたい。
+
+**Why this priority**: 守秘が最優先だが、公開ページの説得力も落としたくないため。
+
+**Independent Test**: `visibility="private"` の実績が混ざっていても、公開側のProjects/Experienceが薄く見えない。
+
+**Acceptance Scenarios**:
+
+1. **Given** private project が存在する、**When** Projects を見る、**Then** 機密を漏らさず「どんな課題領域/役割/インパクトか」が最小情報で伝わる
+2. **Given** private override が落ちる、**When** 表示する、**Then** public の文章で破綻なく成立する（壊れない）
+
+---
+
+### User Story 3 - 連絡導線が明確で行動に繋がる (Priority: P3)
+
+採用担当/協業相手として、何を依頼できる人かが分かり、連絡手段を迷わず選べる。
+
+**Why this priority**: CTAの強さはコンバージョン（連絡）に直結するため。
+
+**Independent Test**: Contactを見て、どの手段で連絡すべきか迷わない。
+
+**Acceptance Scenarios**:
+
+1. **Given** Contact を開く、**When** 文面を見る、**Then** 依頼/相談の例と返信期待（目安）が明確
+2. **Given** 外部リンクをクリックする、**When** 別タブで開く、**Then** 安全に開く（`rel="noreferrer"` 等）
+
+---
+
+### Edge Cases
+
+- publicPortfolio だけの場合（private override無し）でも文脈が壊れない
+- private override が部分的（Experienceだけ/Projectsだけ）でも成立する
+- `visibility="private"` が多い場合でも Projects がスカスカに見えない
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: 公開ページの主要コピー（Profile/Experience/Projects/Contact）は placeholder を含まず、読める文章で成立しなければならない
+- **FR-002**: Projects の各カードは最低限「title/summary/role/tech/outcomeOrLearning」を満たさなければならない（privateの場合はredaction方針に従う）
+- **FR-003**: Experience は「期間感/責務/成果（定量 or 代替表現）」が少なくとも1つは含まれなければならない（守秘範囲で）
+- **FR-004**: Contact には “何を連絡してほしいか” の例が含まれなければならない
+- **FR-005**: 既存の private overrides（env/url）機構を壊さず、public-only でも壊れない
+
+### Key Entities *(include if feature involves data)*
+
+- **Experience**: 見せたい責務・成果・期間感（公開用の最小単位）
+- **Project**: 公開/非公開の見せ方（redaction込み）
+- **Contact CTA**: 依頼の種類/期待値
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 初見ユーザーが2分で「強み・実績」を要約できる（第三者レビューで確認）
+- **SC-002**: public-only でも placeholder/破綻した文章が無い
+- **SC-003**: private project が混ざっても「価値が薄い」印象にならない（カード密度/説明で補完）
+

--- a/specs/004-content-public-story/tasks.md
+++ b/specs/004-content-public-story/tasks.md
@@ -23,9 +23,9 @@ description: "Tasks for Phase 2 Content – Public Storytelling (Experience/Proj
 
 **Purpose**: Align on where content lives and what “done” means for public storytelling.
 
-- [ ] T001 Confirm current content sources and render flow in `src/app/page.tsx` + `src/content/portfolio.ts`
-- [ ] T002 Confirm privacy constraints and redaction behavior for `visibility="private"` in `src/components/sections/ProjectsSection.tsx`
-- [ ] T003 [P] Create a “public-proof writing checklist” in `specs/004-content-public-story/research.md` (NDA-safe phrasing patterns)
+- [x] T001 Confirm current content sources and render flow in `src/app/page.tsx` + `src/content/portfolio.ts`
+- [x] T002 Confirm privacy constraints and redaction behavior for `visibility="private"` in `src/components/sections/ProjectsSection.tsx`
+- [x] T003 [P] Create a “public-proof writing checklist” in `specs/004-content-public-story/research.md` (NDA-safe phrasing patterns)
 
 ---
 
@@ -35,9 +35,9 @@ description: "Tasks for Phase 2 Content – Public Storytelling (Experience/Proj
 
 **⚠️ CRITICAL**: No user story work should begin until this phase is complete.
 
-- [ ] T004 Ensure public-only mode is coherent (no placeholder-ish copy) by reviewing `publicPortfolio` in `src/content/portfolio.ts`
-- [ ] T005 Ensure private override fallback remains safe by validating merge/validation behavior in `src/content/portfolio.ts` (public-only must not crash)
-- [ ] T006 Capture “definition of done” checks inside `specs/004-content-public-story/quickstart.md` (public-only, private override, private redaction)
+- [x] T004 Ensure public-only mode is coherent (no placeholder-ish copy) by reviewing `publicPortfolio` in `src/content/portfolio.ts`
+- [x] T005 Ensure private override fallback remains safe by validating merge/validation behavior in `src/content/portfolio.ts` (public-only must not crash)
+- [x] T006 Capture “definition of done” checks inside `specs/004-content-public-story/quickstart.md` (public-only, private override, private redaction)
 
 **Checkpoint**: Public-only renders cleanly, and private override paths remain optional and safe.
 
@@ -51,11 +51,11 @@ description: "Tasks for Phase 2 Content – Public Storytelling (Experience/Proj
 
 ### Implementation for User Story 1
 
-- [ ] T007 [US1] Rewrite public Experience highlights for evidence + clarity in `src/content/portfolio.ts` (`publicPortfolio.experience.highlights`)
-- [ ] T008 [US1] Rewrite public Projects data to match proof set in `src/content/portfolio.ts` (`publicPortfolio.projects.items`)
-- [ ] T009 [P] [US1] Improve Projects scan-ability layout (role/tech/outcome hierarchy) in `src/components/sections/ProjectsSection.tsx`
-- [ ] T010 [P] [US1] Improve Experience readability (timeline density / spacing) in `src/components/sections/ExperienceSection.tsx`
-- [ ] T011 [US1] Confirm headings are unambiguous and consistent in `src/components/sections/ExperienceSection.tsx` and `src/components/sections/ProjectsSection.tsx`
+- [x] T007 [US1] Rewrite public Experience highlights for evidence + clarity in `src/content/portfolio.ts` (`publicPortfolio.experience.highlights`)
+- [x] T008 [US1] Rewrite public Projects data to match proof set in `src/content/portfolio.ts` (`publicPortfolio.projects.items`)
+- [x] T009 [P] [US1] Improve Projects scan-ability layout (role/tech/outcome hierarchy) in `src/components/sections/ProjectsSection.tsx`
+- [x] T010 [P] [US1] Improve Experience readability (timeline density / spacing) in `src/components/sections/ExperienceSection.tsx`
+- [x] T011 [US1] Confirm headings are unambiguous and consistent in `src/components/sections/ExperienceSection.tsx` and `src/components/sections/ProjectsSection.tsx`
 
 **Checkpoint**: Projects cards “prove” role/tech/outcome; Experience includes timeframe-feel/responsibility/outcome (NDA-safe).
 
@@ -69,10 +69,10 @@ description: "Tasks for Phase 2 Content – Public Storytelling (Experience/Proj
 
 ### Implementation for User Story 2
 
-- [ ] T012 [US2] Define a consistent “private card minimal proof” copy strategy in `src/components/sections/ProjectsSection.tsx` (what to show vs hide)
-- [ ] T013 [US2] Update Projects rendering for `visibility="private"` to avoid “empty card” feel while still redacting (title + safe meta only) in `src/components/sections/ProjectsSection.tsx`
-- [ ] T014 [US2] Review public Projects copy to avoid leaking identifiers (names/URLs/internal terms) in `src/content/portfolio.ts`
-- [ ] T015 [US2] Validate fallback behavior: if private override fails, public-only narrative still stands in `src/content/portfolio.ts`
+- [x] T012 [US2] Define a consistent “private card minimal proof” copy strategy in `src/components/sections/ProjectsSection.tsx` (what to show vs hide)
+- [x] T013 [US2] Update Projects rendering for `visibility="private"` to avoid “empty card” feel while still redacting (title + safe meta only) in `src/components/sections/ProjectsSection.tsx`
+- [x] T014 [US2] Review public Projects copy to avoid leaking identifiers (names/URLs/internal terms) in `src/content/portfolio.ts`
+- [x] T015 [US2] Validate fallback behavior: if private override fails, public-only narrative still stands in `src/content/portfolio.ts`
 
 **Checkpoint**: Private cards are safe by construction; public-only remains coherent; overall Projects section still reads “strong”.
 
@@ -86,9 +86,9 @@ description: "Tasks for Phase 2 Content – Public Storytelling (Experience/Proj
 
 ### Implementation for User Story 3
 
-- [ ] T016 [US3] Rewrite Contact CTA blurb (3–5 “good inbound” examples + response expectation) in `src/content/portfolio.ts` (`publicPortfolio.contact.blurb`)
-- [ ] T017 [US3] Ensure Contact links are safe + correct (mailto / target/rel) in `src/components/sections/ContactSection.tsx`
-- [ ] T018 [US3] Confirm Contact copy matches desired inbound (job / side work / consulting / tech talk) in `src/content/portfolio.ts`
+- [x] T016 [US3] Rewrite Contact CTA blurb (3–5 “good inbound” examples + response expectation) in `src/content/portfolio.ts` (`publicPortfolio.contact.blurb`)
+- [x] T017 [US3] Ensure Contact links are safe + correct (mailto / target/rel) in `src/components/sections/ContactSection.tsx`
+- [x] T018 [US3] Confirm Contact copy matches desired inbound (job / side work / consulting / tech talk) in `src/content/portfolio.ts`
 
 **Checkpoint**: Contact section is specific, actionable, and low-friction.
 
@@ -98,10 +98,10 @@ description: "Tasks for Phase 2 Content – Public Storytelling (Experience/Proj
 
 **Purpose**: Final quality checks and small UX polish without adding dependencies.
 
-- [ ] T019 Run `specs/004-content-public-story/quickstart.md` verification steps (public-only, private override, private redaction)
-- [ ] T020 Run `pnpm lint` and fix any issues
-- [ ] T021 Run `pnpm build` and fix any issues
-- [ ] T022 [P] Mobile scan pass: spacing/typography readability in `src/components/sections/ExperienceSection.tsx`, `src/components/sections/ProjectsSection.tsx`, `src/components/sections/ContactSection.tsx`
+- [x] T019 Run `specs/004-content-public-story/quickstart.md` verification steps (public-only, private override, private redaction)
+- [x] T020 Run `pnpm lint` and fix any issues
+- [x] T021 Run `pnpm build` and fix any issues
+- [x] T022 [P] Mobile scan pass: spacing/typography readability in `src/components/sections/ExperienceSection.tsx`, `src/components/sections/ProjectsSection.tsx`, `src/components/sections/ContactSection.tsx`
 
 ---
 

--- a/specs/004-content-public-story/tasks.md
+++ b/specs/004-content-public-story/tasks.md
@@ -1,0 +1,158 @@
+---
+description: "Tasks for Phase 2 Content – Public Storytelling (Experience/Projects/Contact)"
+---
+
+# Tasks: Phase 2 Content – Public Storytelling (Experience/Projects/Contact)
+
+**Input**: Design documents from `/Users/takeshiwatanabe/EureWorks/private/git/portfolio/specs/004-content-public-story/`  
+**Prerequisites**: `plan.md` (required), `spec.md` (required), `research.md`, `data-model.md`, `contracts/`, `quickstart.md`  
+
+**Tests**: No automated tests requested. Use manual verification in `quickstart.md`, plus `pnpm lint` and `pnpm build`.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and validation.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1/US2/US3)
+- All tasks include exact file paths
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Align on where content lives and what “done” means for public storytelling.
+
+- [ ] T001 Confirm current content sources and render flow in `src/app/page.tsx` + `src/content/portfolio.ts`
+- [ ] T002 Confirm privacy constraints and redaction behavior for `visibility="private"` in `src/components/sections/ProjectsSection.tsx`
+- [ ] T003 [P] Create a “public-proof writing checklist” in `specs/004-content-public-story/research.md` (NDA-safe phrasing patterns)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Establish the baseline so content edits don’t break privacy or coherence.
+
+**⚠️ CRITICAL**: No user story work should begin until this phase is complete.
+
+- [ ] T004 Ensure public-only mode is coherent (no placeholder-ish copy) by reviewing `publicPortfolio` in `src/content/portfolio.ts`
+- [ ] T005 Ensure private override fallback remains safe by validating merge/validation behavior in `src/content/portfolio.ts` (public-only must not crash)
+- [ ] T006 Capture “definition of done” checks inside `specs/004-content-public-story/quickstart.md` (public-only, private override, private redaction)
+
+**Checkpoint**: Public-only renders cleanly, and private override paths remain optional and safe.
+
+---
+
+## Phase 3: User Story 1 - 初見で「何ができる人か」が2分で伝わる (Priority: P1) 🎯 MVP
+
+**Goal**: A first-time visitor can scan Experience + Projects and understand strengths with evidence.
+
+**Independent Test**: A third party can read `Profile → Experience → Projects → Skills` and summarize “strengths + proof” in <2 minutes.
+
+### Implementation for User Story 1
+
+- [ ] T007 [US1] Rewrite public Experience highlights for evidence + clarity in `src/content/portfolio.ts` (`publicPortfolio.experience.highlights`)
+- [ ] T008 [US1] Rewrite public Projects data to match proof set in `src/content/portfolio.ts` (`publicPortfolio.projects.items`)
+- [ ] T009 [P] [US1] Improve Projects scan-ability layout (role/tech/outcome hierarchy) in `src/components/sections/ProjectsSection.tsx`
+- [ ] T010 [P] [US1] Improve Experience readability (timeline density / spacing) in `src/components/sections/ExperienceSection.tsx`
+- [ ] T011 [US1] Confirm headings are unambiguous and consistent in `src/components/sections/ExperienceSection.tsx` and `src/components/sections/ProjectsSection.tsx`
+
+**Checkpoint**: Projects cards “prove” role/tech/outcome; Experience includes timeframe-feel/responsibility/outcome (NDA-safe).
+
+---
+
+## Phase 4: User Story 2 - 守秘しながらも価値が伝わる (Priority: P2)
+
+**Goal**: Private projects don’t leak, but the Projects section still feels strong even with private items mixed in.
+
+**Independent Test**: With at least one `visibility="private"` project in private overrides, the Projects section remains compelling and does not reveal sensitive fields.
+
+### Implementation for User Story 2
+
+- [ ] T012 [US2] Define a consistent “private card minimal proof” copy strategy in `src/components/sections/ProjectsSection.tsx` (what to show vs hide)
+- [ ] T013 [US2] Update Projects rendering for `visibility="private"` to avoid “empty card” feel while still redacting (title + safe meta only) in `src/components/sections/ProjectsSection.tsx`
+- [ ] T014 [US2] Review public Projects copy to avoid leaking identifiers (names/URLs/internal terms) in `src/content/portfolio.ts`
+- [ ] T015 [US2] Validate fallback behavior: if private override fails, public-only narrative still stands in `src/content/portfolio.ts`
+
+**Checkpoint**: Private cards are safe by construction; public-only remains coherent; overall Projects section still reads “strong”.
+
+---
+
+## Phase 5: User Story 3 - 連絡導線が明確で行動に繋がる (Priority: P3)
+
+**Goal**: The reader knows what to contact you about and which channel to use, with minimal friction.
+
+**Independent Test**: Reader can pick a contact method and draft a message without guessing what’s appropriate.
+
+### Implementation for User Story 3
+
+- [ ] T016 [US3] Rewrite Contact CTA blurb (3–5 “good inbound” examples + response expectation) in `src/content/portfolio.ts` (`publicPortfolio.contact.blurb`)
+- [ ] T017 [US3] Ensure Contact links are safe + correct (mailto / target/rel) in `src/components/sections/ContactSection.tsx`
+- [ ] T018 [US3] Confirm Contact copy matches desired inbound (job / side work / consulting / tech talk) in `src/content/portfolio.ts`
+
+**Checkpoint**: Contact section is specific, actionable, and low-friction.
+
+---
+
+## Phase N: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final quality checks and small UX polish without adding dependencies.
+
+- [ ] T019 Run `specs/004-content-public-story/quickstart.md` verification steps (public-only, private override, private redaction)
+- [ ] T020 Run `pnpm lint` and fix any issues
+- [ ] T021 Run `pnpm build` and fix any issues
+- [ ] T022 [P] Mobile scan pass: spacing/typography readability in `src/components/sections/ExperienceSection.tsx`, `src/components/sections/ProjectsSection.tsx`, `src/components/sections/ContactSection.tsx`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies
+- **Foundational (Phase 2)**: Depends on Setup completion (blocks all user stories)
+- **User Stories (Phase 3+)**: Depend on Foundational completion
+  - MVP is **US1** first, then **US2**, then **US3**
+- **Polish**: After desired user stories complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: Can start after Foundational; establishes the narrative baseline
+- **US2 (P2)**: Can start after Foundational; builds on Projects privacy/readability
+- **US3 (P3)**: Can start after Foundational; mostly independent (Contact-only)
+
+### Parallel Opportunities
+
+- `ProjectsSection.tsx` and `ExperienceSection.tsx` changes can be parallelized after T004–T006
+- Content edits in `src/content/portfolio.ts` can be parallelized with UI layout tweaks (different files)
+
+---
+
+## Parallel Example: User Story 1
+
+```text
+Task: "Rewrite Experience highlights in src/content/portfolio.ts"
+Task: "Rewrite Projects data in src/content/portfolio.ts"
+Task: "Improve Projects scan-ability layout in src/components/sections/ProjectsSection.tsx"
+Task: "Improve Experience readability in src/components/sections/ExperienceSection.tsx"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational
+3. Complete Phase 3: US1 (MVP)
+4. Validate using `specs/004-content-public-story/quickstart.md` + quick third-party read-through
+
+### Incremental Delivery
+
+1. Deliver US1 (strong scan narrative)
+2. Deliver US2 (privacy-safe but still compelling)
+3. Deliver US3 (CTA conversion)
+4. Finish with Polish tasks
+
+

--- a/src/components/sections/ContactSection.tsx
+++ b/src/components/sections/ContactSection.tsx
@@ -17,7 +17,7 @@ export async function ContactSection() {
       >
         {contact.heading}
       </h2>
-      <p className="mt-3 text-sm [font-family:var(--font-noto)]">
+      <p className="mt-3 whitespace-pre-line text-sm [font-family:var(--font-noto)]">
         {contact.blurb}
       </p>
       <div className="mt-6 flex flex-wrap gap-3">

--- a/src/components/sections/ExperienceSection.tsx
+++ b/src/components/sections/ExperienceSection.tsx
@@ -13,11 +13,15 @@ export async function ExperienceSection() {
       >
         {experience.heading}
       </h2>
-      <ul className="mt-3 space-y-2 text-sm [font-family:var(--font-noto)]">
+      <ul className="mt-4 space-y-3 text-sm [font-family:var(--font-noto)]">
         {experience.highlights.map((item) => (
           <li key={item.year} className="flex gap-3">
-            <span className="shrink-0 text-fami-gold">{item.year}</span>
-            <span>{item.text}</span>
+            <span className="shrink-0">
+              <span className="nes-badge is-warning text-[0.6rem]">
+                <span>{item.year}</span>
+              </span>
+            </span>
+            <span className="leading-relaxed">{item.text}</span>
           </li>
         ))}
       </ul>

--- a/src/components/sections/ProjectsSection.tsx
+++ b/src/components/sections/ProjectsSection.tsx
@@ -1,5 +1,9 @@
 import { getPortfolio } from "@/content/portfolio";
 
+function isExternalHttpHref(href: string) {
+  return href.startsWith("http://") || href.startsWith("https://");
+}
+
 export async function ProjectsSection() {
   const { projects } = await getPortfolio();
   return (
@@ -15,7 +19,7 @@ export async function ProjectsSection() {
           {projects.heading}
         </h2>
         <span className="text-xs uppercase tracking-[0.3em] text-fami-gold">
-          GRID VIEW
+          CASE FILES
         </span>
       </header>
 
@@ -48,17 +52,34 @@ export async function ProjectsSection() {
               </div>
             </div>
 
-            <p className="mt-2 text-sm [font-family:var(--font-noto)]">
+            <p className="mt-2 text-sm leading-relaxed [font-family:var(--font-noto)]">
               {project.visibility === "private"
-                ? "詳細は面談でお話しできます（NDA等に配慮）。"
+                ? "NDA等に配慮し、公開できる範囲のみ記載しています。詳細は面談で共有できます。"
                 : project.summary}
             </p>
 
-            {project.visibility === "private" ? null : (
-              <dl className="mt-3 space-y-2 text-xs [font-family:var(--font-noto)]">
+            {project.visibility === "private" ? (
+              <div className="mt-3 text-xs [font-family:var(--font-noto)]">
+                <div className="flex flex-wrap gap-1">
+                  <span className="nes-badge is-warning text-[0.55rem]">
+                    <span>Backend/Infra</span>
+                  </span>
+                  <span className="nes-badge is-warning text-[0.55rem]">
+                    <span>Migration</span>
+                  </span>
+                  <span className="nes-badge is-warning text-[0.55rem]">
+                    <span>Reliability</span>
+                  </span>
+                </div>
+                <p className="mt-2 leading-relaxed text-fami-ivory/90">
+                  話せる範囲: 役割/設計観点/意思決定/学び（固有名詞や数値は非公開）
+                </p>
+              </div>
+            ) : (
+              <dl className="mt-3 space-y-3 text-xs [font-family:var(--font-noto)]">
                 <div className="flex gap-2">
                   <dt className="w-20 text-fami-gold">Role</dt>
-                  <dd>{project.role}</dd>
+                  <dd className="font-medium">{project.role}</dd>
                 </div>
                 <div className="flex gap-2">
                   <dt className="w-20 text-fami-gold">Tech</dt>
@@ -72,7 +93,7 @@ export async function ProjectsSection() {
                 </div>
                 <div className="flex gap-2">
                   <dt className="w-20 text-fami-gold">Outcome</dt>
-                  <dd>{project.outcomeOrLearning}</dd>
+                  <dd className="leading-relaxed">{project.outcomeOrLearning}</dd>
                 </div>
               </dl>
             )}
@@ -81,8 +102,8 @@ export async function ProjectsSection() {
               <a
                 className="nes-btn mt-4 w-full text-center"
                 href={project.link.href}
-                target={project.link.href.startsWith("http") ? "_blank" : undefined}
-                rel={project.link.href.startsWith("http") ? "noreferrer" : undefined}
+                target={isExternalHttpHref(project.link.href) ? "_blank" : undefined}
+                rel={isExternalHttpHref(project.link.href) ? "noreferrer" : undefined}
               >
                 {project.link.label}
               </a>

--- a/src/content/portfolio.ts
+++ b/src/content/portfolio.ts
@@ -119,9 +119,21 @@ export const publicPortfolio: Portfolio = {
     id: "experience",
     heading: "Experience",
     highlights: [
-      { year: "2025", text: "プロダクトの体験設計と実装を横断してリード" },
-      { year: "2024", text: "デザインシステム/コンポーネント整備で開発速度を改善" },
-      { year: "2023", text: "Next.js を中心にフロント基盤を刷新" },
+      {
+        year: "2025",
+        text:
+          "Backend Engineer (Go)。運用・開発体験・プロダクト価値の三点をつなぐ改善をリード（設計〜実装〜運用）。",
+      },
+      {
+        year: "2024",
+        text:
+          "信頼性と速度のトレードオフを解消するために、監視/アラート/オンコール運用を整備し、障害対応の再現性を上げた。",
+      },
+      {
+        year: "2019–2023",
+        text:
+          "ML/Data/Platform/Infra領域を横断。要件が曖昧な段階から仕組みに落として運用に乗せる（PoCで終わらせない）を得意領域にした。",
+      },
     ],
   },
   projects: {
@@ -130,23 +142,36 @@ export const publicPortfolio: Portfolio = {
     items: [
       {
         visibility: "public",
-        title: "Retro Commerce",
-        summary: "NES感UIのEC体験。",
-        role: "Front-end",
-        tech: ["TypeScript", "Next.js", "Tailwind"],
-        outcomeOrLearning: "UIの一貫性と可読性を崩さずにスピードを出す型を作れた。",
-        link: { label: "Details", href: "#" },
-        status: "2024",
+        title: "Goによるバックエンド刷新",
+        summary:
+          "既存システムの制約を踏まえつつ、段階移行でリスクを抑えながら置き換えを推進。",
+        role: "Tech Lead / Backend",
+        tech: ["Go", "AWS", "SQL", "Observability"],
+        outcomeOrLearning:
+          "移行の設計（分割/切替/ロールバック）と、運用を含めた品質担保の型を作れた。",
+        status: "2024–2025",
       },
       {
         visibility: "public",
-        title: "Arcade CMS",
-        summary: "レトロテーマの管理画面。",
-        role: "Design Systems",
-        tech: ["React", "Component Design"],
-        outcomeOrLearning: "運用し続けられるコンポーネント粒度を学んだ。",
-        link: { label: "Details", href: "#" },
-        status: "2023",
+        title: "監視・運用改善（Datadog中心）",
+        summary:
+          "障害対応の属人性を下げるため、観測性の底上げとアラート設計を見直し。",
+        role: "Infrastructure / Platform",
+        tech: ["Datadog", "AWS", "SLO", "Incident Response"],
+        outcomeOrLearning:
+          "“見える化”だけで終わらせず、アクションに繋がるメトリクス/アラートに落とす重要性を再確認。",
+        status: "2019–2025",
+      },
+      {
+        visibility: "public",
+        title: "ゼロからのインフラ基盤構築（副業）",
+        summary:
+          "サービス立ち上げ初期から、環境分離/CI/CD/IaCを揃え、継続運用できる土台を構築。",
+        role: "Infra / Full-stack (TypeScript)",
+        tech: ["AWS", "Terraform", "CI/CD", "TypeScript"],
+        outcomeOrLearning:
+          "最初に“運用の標準”を置くことで、後からの速度と安全性が両立できることを実感。",
+        status: "2021–2025",
       },
     ],
   },
@@ -196,7 +221,14 @@ export const publicPortfolio: Portfolio = {
   contact: {
     id: "contact",
     heading: "Contact",
-    blurb: "お気軽にご連絡ください。",
+    blurb:
+      "採用・協業・技術相談など、目的に合わせてご連絡ください。\n\n" +
+      "連絡してほしい内容の例:\n" +
+      "・Backend/Infra の設計・実装・運用改善\n" +
+      "・既存システムの段階移行（リプレース/移行設計/リスク管理）\n" +
+      "・Observability（Datadog等）/SLO/障害対応の仕組み化\n" +
+      "・TypeScript のフルスタック開発\n\n" +
+      "返信目安: 24–48時間以内（状況により前後します）",
     links: [
       { label: "Email", href: "worktkc2018@gmail.com" },
       { label: "X / Twitter", href: "https://x.com/buzz_tkc" },


### PR DESCRIPTION
反映内容（要点）
Experience: NDAに配慮しつつ「責務→仕組み→成果/学び」が伝わる文章へ刷新（年バッジで読みやすく）
Projects: publicの実績を“証拠セット（role/tech/outcome）”で再構成
privateカードは 空に見えない最小情報（安全なバッジ + “話せる範囲”）を表示し、漏洩は回避
Contact: CTAを具体化（依頼例 + 返信目安）、改行を保持して読みやすく
