### PR TITLE
005 blog links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ Unified cheat sheet so any AI agent (Claude Code, GPT, etc.) can understand the 
   - Private overrides can be injected via env vars (no private content committed to git).
   - Skills support categorized groups (`skills.categories`) with a backward-compatible flat list (`skills.items`) derived from categories.
     - Skills use `years` (required) and can optionally include `firstUsedYear` / `lastUsedYear` to show recency.
+  - Writing/Blog links live in `portfolio.writing` and are rendered in `src/components/sections/WritingSection.tsx`.
 
 ## Workflow Expectations
 - Branch from feature branch, open PR → merge to `main` → Vercel autodeploy.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ Focused tips for Anthropic Claude Code / Workbench agents interacting with this 
 - `src/app/page.tsx` – Landing page composition (Hero → TOC → sections). Keep it thin; put content in sections and data in `src/content/portfolio.ts`.
 - `src/components/TableOfContents.tsx` – TOC UI (in-page navigation).
 - `src/components/sections/*` – Semantic sections; each owns a stable `id` for `#hash` navigation.
+- `src/components/sections/WritingSection.tsx` – Writing/blog links section (external links).
 - `src/content/portfolio.ts` – Public content + optional private overrides loaded server-side via env vars:
   - `PORTFOLIO_PRIVATE_SOURCE` = `env` or `url`
   - `PORTFOLIO_PRIVATE_JSON` (JSON string)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Phase 1 of the Famicom-style portfolio for Takeshi Watanabe (Buzz). Built with N
 
 ## What's included now
 
-- Hero + TOC + Profile/Experience/Projects/Skills/Contact sections (single-page) composed via `src/components/*`
+- Hero + TOC + Profile/Experience/Projects/Writing/Skills/Contact sections (single-page) composed via `src/components/*`
 - Famicom palette (red `#a20000`, gold `#d7b05b`, background `#111`) and retro typography (Press Start 2P + Noto Sans JP)
 - NES.css buttons, badges, and progress bars wired up for later polish
 
@@ -24,6 +24,7 @@ src/
       ProfileSection.tsx
       ExperienceSection.tsx
       ProjectsSection.tsx
+      WritingSection.tsx
       SkillsSection.tsx
       ContactSection.tsx
 ```
@@ -68,7 +69,7 @@ When a change affects dependencies or workflows, remember to update README / doc
 
 ## Customizing next steps
 
-- Update the copy/data in `src/content/portfolio.ts` (profile/experience/projects/skills/contact).
+- Update the copy/data in `src/content/portfolio.ts` (profile/experience/projects/writing/skills/contact).
 - If you want to keep some details off the public repo, you can provide private overrides via
   environment variables (see `src/content/portfolio.ts`: `PORTFOLIO_PRIVATE_JSON` or
   `PORTFOLIO_PRIVATE_URL`).

--- a/specs/005-blog-links/contracts/README.md
+++ b/specs/005-blog-links/contracts/README.md
@@ -1,0 +1,7 @@
+# Contracts
+
+This feature adds a new on-page section and does not introduce new external APIs.
+
+- **Contracts**: N/A
+
+

--- a/specs/005-blog-links/data-model.md
+++ b/specs/005-blog-links/data-model.md
@@ -1,0 +1,30 @@
+# Data Model: 005 – Writing / Blog Links
+
+## Overview
+
+This feature adds a new public section to the single-page portfolio for writing/blog links.
+
+## Entities
+
+### Writing (new)
+
+Proposed shape (compatible with existing content patterns):
+
+```ts
+type Writing = SectionContent & {
+  items: ExternalLink[];
+};
+```
+
+**Rules**
+- `items` must include at least:
+  - Tech blog (Medium)
+  - Casual blog (しずかなインターネット)
+- Links are external and must be rendered safely (`target="_blank"` + `rel="noreferrer"`).
+
+## Relationships
+
+- `Portfolio.writing` is a sibling section alongside `profile/experience/projects/skills/contact`.
+- `Writing.id` must match the TOC id for anchor navigation.
+
+

--- a/specs/005-blog-links/plan.md
+++ b/specs/005-blog-links/plan.md
@@ -1,0 +1,100 @@
+# Implementation Plan: 005 – Writing / Blog Links
+
+**Branch**: `005-blog-links` | **Date**: 2025-12-25 | **Spec**: `specs/005-blog-links/spec.md`  
+**Input**: Feature specification from `specs/005-blog-links/spec.md`
+
+## Summary
+
+Add a new **Writing/Blog** entry point to the single-page portfolio, linking to:
+- Tech blog (Medium): `https://medium.com/@buzz_tkc`
+- Casual blog (しずかなインターネット): `https://sizu.me/buzz`
+
+This is link-only v1 (no RSS/latest post fetching) to keep the site lightweight and durable.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x (Next.js 16 App Router)  
+**Primary Dependencies**: Next.js, React 19, Tailwind CSS, NES.css  
+**Storage**: N/A (static content) + optional private override via env/url (server-side fetch)  
+**Testing**: No automated tests; quality gates are `pnpm lint` + `pnpm build`  
+**Target Platform**: Vercel  
+**Project Type**: Web application (single-page portfolio)  
+**Performance Goals**: Keep it lightweight; avoid new runtime deps  
+**Constraints**: Preserve TOC UX; external links must be safe (`target="_blank"` + `rel="noreferrer"`)  
+**Scale/Scope**: Add 1 new semantic section + 1 TOC item, backed by `src/content/portfolio.ts`
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- Principle compliance: Adds “writing” as a proof surface for “Personality-First Storytelling”.
+- Retro aesthetic + usability: Keep it scan-friendly; reuse existing section styling.
+- Quality gates: `pnpm lint` and `pnpm build` pass.
+- Docs sync: Adding a new top-level section/TOC item is a UX change → update `README.md`, `AGENTS.md`, `CLAUDE.md`.
+
+**Gate Result (pre-research)**: PASS
+
+## Phase 0: Outline & Research
+
+### Key decisions
+
+- **Link-only vs latest posts (RSS)**:
+  - Decision: **Link-only** for v1 (no deps / no external fetch complexity).
+  - Keep RSS/latest-posts as a future enhancement if desired.
+
+**Output**: `specs/005-blog-links/research.md`
+
+## Phase 1: Design & Contracts
+
+### Data model
+
+- Add a `writing` section to the portfolio content model:
+  - `id`, `heading`, `items: ExternalLink[]`
+
+**Output**: `specs/005-blog-links/data-model.md`
+
+### Contracts
+
+- No new external APIs introduced.  
+**Output**: `specs/005-blog-links/contracts/README.md` (N/A)
+
+### Quickstart
+
+Verify TOC navigation + both blog links open safely.  
+**Output**: `specs/005-blog-links/quickstart.md`
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/005-blog-links/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── README.md
+└── tasks.md             # created by /speckit.tasks (next step)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── app/
+│   └── page.tsx
+├── components/
+│   ├── TableOfContents.tsx
+│   ├── toc.ts
+│   └── sections/
+│       └── WritingSection.tsx   # NEW
+└── content/
+    └── portfolio.ts
+```
+
+**Structure Decision**: Keep `page.tsx` thin; put link data in `src/content/portfolio.ts` and render via `WritingSection`.
+
+## Re-check Constitution (post-design)
+
+**Gate Result (post-design)**: PASS (expected; small UX + content change)

--- a/specs/005-blog-links/quickstart.md
+++ b/specs/005-blog-links/quickstart.md
@@ -1,0 +1,32 @@
+# Quickstart: 005 – Writing / Blog Links
+
+## Goal
+
+Verify that the portfolio exposes blog links clearly and safely via a dedicated Writing section.
+
+## Setup
+
+```bash
+cd /Users/takeshiwatanabe/EureWorks/private/git/portfolio
+pnpm install
+pnpm dev
+```
+
+Open `http://localhost:3000`.
+
+## Verification checklist
+
+1. **TOC navigation**
+   - Click the TOC item `Writing` and confirm it scrolls to the Writing section.
+2. **Links**
+   - Confirm both links exist:
+     - Tech blog (Medium): `https://medium.com/@buzz_tkc`
+     - Casual blog: `https://sizu.me/buzz`
+3. **Safety**
+   - Links open in a new tab.
+   - External links include `rel="noreferrer"`.
+4. **Quality gates**
+   - `pnpm lint`
+   - `pnpm build`
+
+

--- a/specs/005-blog-links/research.md
+++ b/specs/005-blog-links/research.md
@@ -1,0 +1,22 @@
+# Research: 005 – Writing / Blog Links
+
+## Decision 1: Link-only vs latest posts (RSS)
+
+- **Decision**: Link-only (v1)
+- **Rationale**: Avoid new deps and external fetch/parsing. Keep the portfolio durable and fast.
+- **Alternatives considered**:
+  - Fetch RSS/Atom and render latest posts → rejected for v1 (extra complexity + reliability concerns)
+
+## Decision 2: Where to place blog links
+
+- **Decision**: Add a dedicated `Writing` section + TOC entry.
+- **Rationale**: Makes the “writing proof surface” obvious and discoverable. Keeps Contact focused on contact channels.
+- **Alternatives considered**:
+  - Put links into `Contact` only → rejected (discoverability; dilutes CTA)
+
+## Decision 3: External link safety
+
+- **Decision**: For external links, open in new tab and set `rel="noreferrer"`.
+- **Rationale**: Standard safety practice; avoids leaking referrer and prevents tabnabbing patterns.
+
+

--- a/specs/005-blog-links/spec.md
+++ b/specs/005-blog-links/spec.md
@@ -1,0 +1,59 @@
+# Feature Specification: 005 – Writing / Blog Links
+
+**Feature Branch**: `005-blog-links`  
+**Created**: 2025-12-25  
+**Status**: Draft  
+**Input**: User description: "自身のblogを載せたい（Tech: Medium / Casual: しずかなインターネット）"
+
+## Scope
+
+- Add a **Writing** (or **Blog**) entry point on the portfolio page that links to:
+  - Tech blog (Medium): `https://medium.com/@buzz_tkc`
+  - Casual blog (しずかなインターネット): `https://sizu.me/buzz`
+
+## Non-goals / constraints
+
+- No scraping or auth. Link-only is sufficient for v1.
+- Avoid adding new runtime dependencies.
+- Preserve the single-page UX + TOC navigation.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - 読者がブログへ迷わず到達できる (Priority: P1)
+
+採用/協業の読者として、ポートフォリオを読んだ後に文章（テック寄り/雑記寄り）も見て人物像を掴みたい。
+
+**Why this priority**: 文章は価値観/判断/継続性の証拠になり、ポートフォリオの説得力を上げるため。
+
+**Independent Test**: TOCからWritingへ移動し、2つのリンクが安全に開ける（外部は別タブ + `rel="noreferrer"`）。
+
+**Acceptance Scenarios**:
+
+1. **Given** ポートフォリオを開く、**When** TOCからWritingへ移動する、**Then** Writingセクションが見える
+2. **Given** Writingセクションを見る、**When** Tech/Casual blogリンクを押す、**Then** 正しいURLが別タブで開く（安全属性付き）
+
+---
+
+### Edge Cases
+
+- TOC項目追加で8項目を超えない（超える場合は統合）
+- 外部リンクが一時的に落ちていてもページ自体は壊れない
+- 既存の private overrides 機構を壊さない（このfeatureはpublic側の導線追加のみ）
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: ポートフォリオ上にブログ導線（Writing/Blog）が存在しなければならない
+- **FR-002**: Tech blog と Casual blog の2リンクを表示しなければならない
+- **FR-003**: 外部リンクは別タブで開き、`rel="noreferrer"` を付与しなければならない
+- **FR-004**: 既存のTOC/アンカー移動のUXを壊してはならない
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 読者が1クリックでTech/Casual blogへ到達できる
+- **SC-002**: `pnpm lint` と `pnpm build` が通る
+
+

--- a/specs/005-blog-links/tasks.md
+++ b/specs/005-blog-links/tasks.md
@@ -23,9 +23,9 @@ description: "Tasks for 005 – Writing / Blog Links"
 
 **Purpose**: Confirm the integration points for adding a new section + TOC entry.
 
-- [ ] T001 Confirm current TOC config and section composition in `src/components/toc.ts` and `src/app/page.tsx`
-- [ ] T002 Confirm current content source-of-truth patterns in `src/content/portfolio.ts`
-- [ ] T003 [P] Confirm link safety pattern (`target="_blank"` + `rel="noreferrer"`) in existing sections (`src/components/sections/ContactSection.tsx`, `src/components/sections/ProjectsSection.tsx`)
+- [x] T001 Confirm current TOC config and section composition in `src/components/toc.ts` and `src/app/page.tsx`
+- [x] T002 Confirm current content source-of-truth patterns in `src/content/portfolio.ts`
+- [x] T003 [P] Confirm link safety pattern (`target="_blank"` + `rel="noreferrer"`) in existing sections (`src/components/sections/ContactSection.tsx`, `src/components/sections/ProjectsSection.tsx`)
 
 ---
 
@@ -35,9 +35,9 @@ description: "Tasks for 005 – Writing / Blog Links"
 
 **⚠️ CRITICAL**: No user story work should begin until this phase is complete.
 
-- [ ] T004 Decide and fix the new TOC id (`writing`) and label (`Writing`) in `src/components/toc.ts`
-- [ ] T005 Add the new section component file `src/components/sections/WritingSection.tsx` (server component, same frame styling)
-- [ ] T006 Wire the section into page composition in `src/app/page.tsx` (keep page thin; preserve section order)
+- [x] T004 Decide and fix the new TOC id (`writing`) and label (`Writing`) in `src/components/toc.ts`
+- [x] T005 Add the new section component file `src/components/sections/WritingSection.tsx` (server component, same frame styling)
+- [x] T006 Wire the section into page composition in `src/app/page.tsx` (keep page thin; preserve section order)
 
 **Checkpoint**: The app compiles and `#writing` anchor exists (even before content polish).
 
@@ -51,10 +51,10 @@ description: "Tasks for 005 – Writing / Blog Links"
 
 ### Implementation for User Story 1
 
-- [ ] T007 [US1] Add `writing` section data (heading + two links) to `src/content/portfolio.ts`
-- [ ] T008 [US1] Render blog links in `src/components/sections/WritingSection.tsx` (NES buttons + short labels: “Tech (Medium)”, “Casual”)
-- [ ] T009 [US1] Ensure external links are safe in `src/components/sections/WritingSection.tsx` (`target="_blank"`, `rel="noreferrer"`)
-- [ ] T010 [US1] Keep TOC count reasonable (<= 8 items) and verify TOC labels remain scannable in `src/components/toc.ts`
+- [x] T007 [US1] Add `writing` section data (heading + two links) to `src/content/portfolio.ts`
+- [x] T008 [US1] Render blog links in `src/components/sections/WritingSection.tsx` (NES buttons + short labels: “Tech (Medium)”, “Casual”)
+- [x] T009 [US1] Ensure external links are safe in `src/components/sections/WritingSection.tsx` (`target="_blank"`, `rel="noreferrer"`)
+- [x] T010 [US1] Keep TOC count reasonable (<= 8 items) and verify TOC labels remain scannable in `src/components/toc.ts`
 
 **Checkpoint**: Writing section is reachable via TOC and contains the two correct URLs.
 
@@ -64,10 +64,10 @@ description: "Tasks for 005 – Writing / Blog Links"
 
 **Purpose**: Finish with quality gates and doc sync (top-level UX changed).
 
-- [ ] T011 Update docs to mention the new Writing section in `README.md`, `AGENTS.md`, and `CLAUDE.md`
-- [ ] T012 Run `specs/005-blog-links/quickstart.md` verification steps
-- [ ] T013 Run `pnpm lint` and fix any issues
-- [ ] T014 Run `pnpm build` and fix any issues
+- [x] T011 Update docs to mention the new Writing section in `README.md`, `AGENTS.md`, and `CLAUDE.md`
+- [x] T012 Run `specs/005-blog-links/quickstart.md` verification steps
+- [x] T013 Run `pnpm lint` and fix any issues
+- [x] T014 Run `pnpm build` and fix any issues
 
 ---
 

--- a/specs/005-blog-links/tasks.md
+++ b/specs/005-blog-links/tasks.md
@@ -1,0 +1,101 @@
+---
+description: "Tasks for 005 – Writing / Blog Links"
+---
+
+# Tasks: 005 – Writing / Blog Links
+
+**Input**: Design documents from `/Users/takeshiwatanabe/EureWorks/private/git/portfolio/specs/005-blog-links/`  
+**Prerequisites**: `plan.md` (required), `spec.md` (required), `research.md`, `data-model.md`, `contracts/`, `quickstart.md`  
+
+**Tests**: No automated tests requested. Verify via `quickstart.md`, plus `pnpm lint` and `pnpm build`.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and validation.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1)
+- All tasks include exact file paths
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm the integration points for adding a new section + TOC entry.
+
+- [ ] T001 Confirm current TOC config and section composition in `src/components/toc.ts` and `src/app/page.tsx`
+- [ ] T002 Confirm current content source-of-truth patterns in `src/content/portfolio.ts`
+- [ ] T003 [P] Confirm link safety pattern (`target="_blank"` + `rel="noreferrer"`) in existing sections (`src/components/sections/ContactSection.tsx`, `src/components/sections/ProjectsSection.tsx`)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Ensure a new section can be added without breaking navigation or docs.
+
+**⚠️ CRITICAL**: No user story work should begin until this phase is complete.
+
+- [ ] T004 Decide and fix the new TOC id (`writing`) and label (`Writing`) in `src/components/toc.ts`
+- [ ] T005 Add the new section component file `src/components/sections/WritingSection.tsx` (server component, same frame styling)
+- [ ] T006 Wire the section into page composition in `src/app/page.tsx` (keep page thin; preserve section order)
+
+**Checkpoint**: The app compiles and `#writing` anchor exists (even before content polish).
+
+---
+
+## Phase 3: User Story 1 - 読者がブログへ迷わず到達できる (Priority: P1) 🎯 MVP
+
+**Goal**: Readers can jump to Writing and open Tech/Casual blogs safely.
+
+**Independent Test**: From TOC → Writing, both links open in a new tab with `rel="noreferrer"`.
+
+### Implementation for User Story 1
+
+- [ ] T007 [US1] Add `writing` section data (heading + two links) to `src/content/portfolio.ts`
+- [ ] T008 [US1] Render blog links in `src/components/sections/WritingSection.tsx` (NES buttons + short labels: “Tech (Medium)”, “Casual”)
+- [ ] T009 [US1] Ensure external links are safe in `src/components/sections/WritingSection.tsx` (`target="_blank"`, `rel="noreferrer"`)
+- [ ] T010 [US1] Keep TOC count reasonable (<= 8 items) and verify TOC labels remain scannable in `src/components/toc.ts`
+
+**Checkpoint**: Writing section is reachable via TOC and contains the two correct URLs.
+
+---
+
+## Phase N: Polish & Cross-Cutting Concerns
+
+**Purpose**: Finish with quality gates and doc sync (top-level UX changed).
+
+- [ ] T011 Update docs to mention the new Writing section in `README.md`, `AGENTS.md`, and `CLAUDE.md`
+- [ ] T012 Run `specs/005-blog-links/quickstart.md` verification steps
+- [ ] T013 Run `pnpm lint` and fix any issues
+- [ ] T014 Run `pnpm build` and fix any issues
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies
+- **Foundational (Phase 2)**: Depends on Setup completion (blocks US1)
+- **User Stories (Phase 3+)**: Depend on Foundational completion
+- **Polish**: After US1 is complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: Can start after Foundational; no dependencies on other stories (only story in this spec)
+
+### Parallel Opportunities
+
+- T003 can run in parallel (read-only confirmation across files)
+- Once T004–T006 are done, T007 (data) and T008–T009 (UI) are separable by file
+
+---
+
+## Parallel Example: User Story 1
+
+```text
+Task: "Add writing section data to src/content/portfolio.ts"
+Task: "Render WritingSection UI in src/components/sections/WritingSection.tsx"
+```
+
+

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import { ExperienceSection } from "@/components/sections/ExperienceSection";
 import { ProfileSection } from "@/components/sections/ProfileSection";
 import { ProjectsSection } from "@/components/sections/ProjectsSection";
 import { SkillsSection } from "@/components/sections/SkillsSection";
+import { WritingSection } from "@/components/sections/WritingSection";
 
 export default function Home() {
   return (
@@ -15,6 +16,7 @@ export default function Home() {
         <ProfileSection />
         <ExperienceSection />
         <ProjectsSection />
+        <WritingSection />
         <SkillsSection />
         <ContactSection />
       </div>

--- a/src/components/sections/WritingSection.tsx
+++ b/src/components/sections/WritingSection.tsx
@@ -1,0 +1,45 @@
+import { getPortfolio } from "@/content/portfolio";
+
+function isExternalHttpHref(href: string) {
+  return href.startsWith("http://") || href.startsWith("https://");
+}
+
+export async function WritingSection() {
+  const { writing } = await getPortfolio();
+  return (
+    <section
+      id={writing.id}
+      className="scroll-mt-6 frame bg-[#1b1b1b] p-6 text-fami-ivory"
+    >
+      <h2
+        className="text-xl text-fami-gold"
+        style={{ fontFamily: "var(--font-press)" }}
+      >
+        {writing.heading}
+      </h2>
+
+      <p className="mt-3 text-sm [font-family:var(--font-noto)]">
+        技術記事と雑記を分けて書いています。
+      </p>
+
+      <div className="mt-6 flex flex-wrap gap-3">
+        {writing.items.map((link) => {
+          const isExternal = isExternalHttpHref(link.href);
+          return (
+            <a
+              key={link.href}
+              className="nes-btn is-primary"
+              href={link.href}
+              target={isExternal ? "_blank" : undefined}
+              rel={isExternal ? "noreferrer" : undefined}
+            >
+              {link.label}
+            </a>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+

--- a/src/components/toc.ts
+++ b/src/components/toc.ts
@@ -1,4 +1,10 @@
-export type TocItemId = "profile" | "experience" | "projects" | "skills" | "contact";
+export type TocItemId =
+  | "profile"
+  | "experience"
+  | "projects"
+  | "writing"
+  | "skills"
+  | "contact";
 
 export type TocItem = {
   id: TocItemId;
@@ -9,6 +15,7 @@ export const TOC_ITEMS: TocItem[] = [
   { id: "profile", label: "Profile" },
   { id: "experience", label: "Experience" },
   { id: "projects", label: "Projects" },
+  { id: "writing", label: "Writing" },
   { id: "skills", label: "Skills" },
   { id: "contact", label: "Contact" },
 ];

--- a/src/content/portfolio.ts
+++ b/src/content/portfolio.ts
@@ -63,12 +63,14 @@ export type Profile = SectionContent & { body: string };
 export type Experience = SectionContent & { highlights: ExperienceHighlight[] };
 export type Projects = SectionContent & { items: Project[] };
 export type Skills = SectionContent & { items: Skill[]; categories?: SkillCategory[] };
+export type Writing = SectionContent & { items: ExternalLink[] };
 export type Contact = SectionContent & { blurb: string; links: ExternalLink[] };
 
 export type Portfolio = {
   profile: Profile;
   experience: Experience;
   projects: Projects;
+  writing: Writing;
   skills: Skills;
   contact: Contact;
 };
@@ -175,6 +177,14 @@ export const publicPortfolio: Portfolio = {
       },
     ],
   },
+  writing: {
+    id: "writing",
+    heading: "Writing",
+    items: [
+      { label: "Tech (Medium)", href: "https://medium.com/@buzz_tkc" },
+      { label: "Casual (sizu.me)", href: "https://sizu.me/buzz" },
+    ],
+  },
   skills: {
     id: "skills",
     heading: "Skills",
@@ -259,6 +269,7 @@ function isPortfolioPatch(value: unknown): value is Partial<Portfolio> {
     "profile" in value ||
     "experience" in value ||
     "projects" in value ||
+    "writing" in value ||
     "skills" in value ||
     "contact" in value
   );
@@ -270,6 +281,7 @@ function mergePortfolio(base: Portfolio, patch: Partial<Portfolio>): Portfolio {
     profile: { ...base.profile, ...(patch.profile ?? {}) },
     experience: { ...base.experience, ...(patch.experience ?? {}) },
     projects: { ...base.projects, ...(patch.projects ?? {}) },
+    writing: { ...base.writing, ...(patch.writing ?? {}) },
     skills: { ...base.skills, ...(patch.skills ?? {}) },
     contact: { ...base.contact, ...(patch.contact ?? {}) },
   };
@@ -420,5 +432,6 @@ export async function getPortfolio(): Promise<Portfolio> {
 export const profile = publicPortfolio.profile;
 export const experience = publicPortfolio.experience;
 export const projects = publicPortfolio.projects;
+export const writing = publicPortfolio.writing;
 export const skills = publicPortfolio.skills;
 export const contact = publicPortfolio.contact;


### PR DESCRIPTION
目的
ポートフォリオ上に Writing（Blog）導線を追加し、文章（Tech/Casual）から人物像を補強できるようにする。
変更内容
TOCに Writing を追加（#writing へアンカー移動）
Writingセクションを追加
Tech blog: https://medium.com/@buzz_tkc
Casual blog: https://sizu.me/buzz
外部リンクは 別タブ + rel="noreferrer"
データモデル/コンテンツ
src/content/portfolio.ts に portfolio.writing を追加（private override merge も対応）