### PR TITLE
006-activities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ Unified cheat sheet so any AI agent (Claude Code, GPT, etc.) can understand the 
   - Skills support categorized groups (`skills.categories`) with a backward-compatible flat list (`skills.items`) derived from categories.
     - Skills use `years` (required) and can optionally include `firstUsedYear` / `lastUsedYear` to show recency.
   - Writing/Blog links live in `portfolio.writing` and are rendered in `src/components/sections/WritingSection.tsx`.
+  - Activities (Talks/Books/Community) live in `portfolio.activities` and are rendered in `src/components/sections/ActivitiesSection.tsx`.
 
 ## Workflow Expectations
 - Branch from feature branch, open PR → merge to `main` → Vercel autodeploy.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ Focused tips for Anthropic Claude Code / Workbench agents interacting with this 
 - `src/components/TableOfContents.tsx` – TOC UI (in-page navigation).
 - `src/components/sections/*` – Semantic sections; each owns a stable `id` for `#hash` navigation.
 - `src/components/sections/WritingSection.tsx` – Writing/blog links section (external links).
+- `src/components/sections/ActivitiesSection.tsx` – Activities section (Talks/Books/Community).
 - `src/content/portfolio.ts` – Public content + optional private overrides loaded server-side via env vars:
   - `PORTFOLIO_PRIVATE_SOURCE` = `env` or `url`
   - `PORTFOLIO_PRIVATE_JSON` (JSON string)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Phase 1 of the Famicom-style portfolio for Takeshi Watanabe (Buzz). Built with N
 
 ## What's included now
 
-- Hero + TOC + Profile/Experience/Projects/Writing/Skills/Contact sections (single-page) composed via `src/components/*`
+- Hero + TOC + Profile/Experience/Projects/Writing/Activities/Skills/Contact sections (single-page) composed via `src/components/*`
 - Famicom palette (red `#a20000`, gold `#d7b05b`, background `#111`) and retro typography (Press Start 2P + Noto Sans JP)
 - NES.css buttons, badges, and progress bars wired up for later polish
 
@@ -25,6 +25,7 @@ src/
       ExperienceSection.tsx
       ProjectsSection.tsx
       WritingSection.tsx
+      ActivitiesSection.tsx
       SkillsSection.tsx
       ContactSection.tsx
 ```
@@ -69,7 +70,7 @@ When a change affects dependencies or workflows, remember to update README / doc
 
 ## Customizing next steps
 
-- Update the copy/data in `src/content/portfolio.ts` (profile/experience/projects/writing/skills/contact).
+- Update the copy/data in `src/content/portfolio.ts` (profile/experience/projects/writing/activities/skills/contact).
 - If you want to keep some details off the public repo, you can provide private overrides via
   environment variables (see `src/content/portfolio.ts`: `PORTFOLIO_PRIVATE_JSON` or
   `PORTFOLIO_PRIVATE_URL`).

--- a/specs/006-activities/contracts/README.md
+++ b/specs/006-activities/contracts/README.md
@@ -1,0 +1,7 @@
+# Contracts
+
+This feature adds on-page content and does not introduce new external APIs.
+
+- **Contracts**: N/A
+
+

--- a/specs/006-activities/data-model.md
+++ b/specs/006-activities/data-model.md
@@ -1,0 +1,47 @@
+# Data Model: 006 – Activities (Talks / Books / Community)
+
+## Overview
+
+This feature adds a new public proof surface for talks, books, and community contributions.
+
+## Entities
+
+### ActivityItem (new)
+
+```ts
+type ActivityItem = {
+  year: string;
+  title: string;
+  context?: string; // event / publisher / role (optional)
+  link?: ExternalLink; // optional external link
+};
+```
+
+### ActivityGroup (new)
+
+```ts
+type ActivityGroup = {
+  name: "Talks" | "Books" | "Community";
+  items: ActivityItem[];
+};
+```
+
+### ActivitiesSection (new)
+
+```ts
+type Activities = SectionContent & {
+  groups: ActivityGroup[];
+};
+```
+
+## Relationships
+
+- `Portfolio.activities` is a sibling of `portfolio.writing`.
+- `activities.id` must match the TOC id for anchor navigation (`#activities`).
+
+## Validation rules (UI-level)
+
+- Empty groups are allowed, but the section should show a clear empty state (“Coming soon”).
+- External links must be rendered safely (`target="_blank"` + `rel="noreferrer"`).
+
+

--- a/specs/006-activities/plan.md
+++ b/specs/006-activities/plan.md
@@ -1,0 +1,105 @@
+# Implementation Plan: 006 – Activities (Talks / Books / Community)
+
+**Branch**: `006-activities` | **Date**: 2025-12-25 | **Spec**: `specs/006-activities/spec.md`  
+**Input**: Feature specification from `specs/006-activities/spec.md`
+
+## Summary
+
+Add an “Activities” proof surface to showcase:
+- Talks (登壇)
+- Books (書籍執筆)
+- Community (コミュニティ活動)
+
+Key IA decision: keep this separate from `Writing` (blog) vs merge them into one section.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x (Next.js 16 App Router)  
+**Primary Dependencies**: Next.js, React 19, Tailwind CSS, NES.css  
+**Storage**: N/A (static content) + optional private override via env/url (server-side fetch)  
+**Testing**: No automated tests; quality gates are `pnpm lint` + `pnpm build`  
+**Target Platform**: Vercel  
+**Project Type**: Web application (single-page portfolio)  
+**Performance Goals**: Keep it lightweight; avoid new runtime deps  
+**Constraints**: Preserve TOC UX (<= 8 items guideline), external links must be safe (`target="_blank"` + `rel="noreferrer"`)  
+**Scale/Scope**: Add Activities section (and possibly TOC item), backed by `src/content/portfolio.ts`
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- Principle compliance: Adds concrete evidence for “Personality-First Storytelling”.
+- Retro aesthetic + usability: Keep it scan-friendly; reuse existing section styling.
+- Quality gates: `pnpm lint` and `pnpm build` pass.
+- Docs sync: Adding a new top-level section/TOC item is a UX change → update `README.md`, `AGENTS.md`, `CLAUDE.md`.
+
+**Gate Result (pre-research)**: PASS
+
+## Phase 0: Outline & Research
+
+### Decisions / NEEDS CLARIFICATION
+
+- **Split vs merge with Writing**
+  - Current TOC has 6 items (Profile/Experience/Projects/Writing/Skills/Contact).
+  - If split: 7 items → still within the “8 items” guideline.
+  - If merge: fewer TOC items, but a larger section that may reduce clarity.
+  - Default recommendation: **split** (Writing = articles, Activities = talks/books/community).
+
+- **Item schema / density**
+  - Minimum: `title`, `year`, optional `context` (event/publisher/role), optional `link`.
+  - Group headings: Talks / Books / Community.
+  - Empty state: explicit “Coming soon” when no items.
+
+**Output**: `specs/006-activities/research.md`
+
+## Phase 1: Design & Contracts
+
+### Data model
+
+- Add an `activities` section to portfolio content:
+  - `id`, `heading`, `groups[]` where each group has `name` and `items[]`.
+
+### Contracts
+
+- No new external APIs introduced (link-only).  
+
+### Quickstart
+
+- Verify TOC navigation + external link safety + empty-state behavior.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/006-activities/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── README.md
+└── tasks.md             # created by /speckit.tasks (next step)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── app/
+│   └── page.tsx
+├── components/
+│   ├── TableOfContents.tsx
+│   ├── toc.ts
+│   └── sections/
+│       ├── WritingSection.tsx
+│       └── ActivitiesSection.tsx   # NEW (if split)
+└── content/
+    └── portfolio.ts
+```
+
+**Structure Decision**: Add `ActivitiesSection` and a TOC item unless we later justify merging with `Writing`.
+
+## Re-check Constitution (post-design)
+
+**Gate Result (post-design)**: PASS (expected; small UX + content change)

--- a/specs/006-activities/quickstart.md
+++ b/specs/006-activities/quickstart.md
@@ -1,0 +1,30 @@
+# Quickstart: 006 – Activities (Talks / Books / Community)
+
+## Goal
+
+Verify that Activities is discoverable, scannable, and safe (external links).
+
+## Setup
+
+```bash
+cd /Users/takeshiwatanabe/EureWorks/private/git/portfolio
+pnpm install
+pnpm dev
+```
+
+Open `http://localhost:3000`.
+
+## Verification checklist
+
+1. **TOC navigation**
+   - Click TOC item `Activities` and confirm it scrolls to `#activities`.
+2. **Content**
+   - Confirm `Talks / Books / Community` group headings render.
+   - If any group has 0 items, ensure an explicit empty state is shown.
+3. **Link safety**
+   - Any external links open in a new tab and include `rel="noreferrer"`.
+4. **Quality gates**
+   - `pnpm lint`
+   - `pnpm build`
+
+

--- a/specs/006-activities/research.md
+++ b/specs/006-activities/research.md
@@ -1,0 +1,24 @@
+# Research: 006 – Activities (Talks / Books / Community)
+
+## Decision 1: Split vs merge with Writing
+
+- **Decision**: Split (recommended default)
+  - Keep `Writing` for blog/articles.
+  - Add `Activities` for talks/books/community.
+- **Rationale**: Current TOC has 6 items, so adding one more stays within the “8 items” guideline while keeping semantics clear.
+- **Alternatives considered**:
+  - Merge into “Writing & Activities” → fewer TOC items, but the section becomes larger and less scannable.
+
+## Decision 2: Data shape for Activities
+
+- **Decision**: Grouped list: Talks / Books / Community
+- **Rationale**: Readers scan by category; each item can remain minimal and NDA-safe.
+- **Alternatives considered**:
+  - One flat list with tags → more flexible but noisier and harder to scan.
+
+## Decision 3: External link safety
+
+- **Decision**: External links open in new tab with `rel="noreferrer"`.
+- **Rationale**: Matches existing safety pattern in the repo and avoids referrer leakage/tabnabbing patterns.
+
+

--- a/specs/006-activities/spec.md
+++ b/specs/006-activities/spec.md
@@ -1,0 +1,79 @@
+# Feature Specification: 006 – Activities (Talks / Books / Community)
+
+**Feature Branch**: `006-activities`  
+**Created**: 2025-12-25  
+**Status**: Draft  
+**Input**: User description: "登壇歴、書籍の執筆、コミュニティ活動などをまとめたい。blogと一緒にするか分けるかは考えたい。"
+
+## Scope
+
+- Add an **Activities** proof surface for:
+  - **Talks** (登壇)
+  - **Books** (書籍執筆)
+  - **Community** (コミュニティ活動)
+- Decide IA:
+  - **Option A**: Keep `Writing` as-is and add a separate `Activities` section + TOC item
+  - **Option B**: Merge into a single section (e.g., `Writing & Activities`) to keep TOC compact
+
+## Non-goals / constraints
+
+- No scraping / auth / API integration for v1 (link-only + short metadata is enough).
+- Avoid adding new runtime dependencies.
+- Preserve the single-page UX + TOC navigation (<= 8 items guideline).
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - 第三者が「アウトプット/社会的活動」を把握できる (Priority: P1)
+
+採用/協業の読者として、プロダクト実績だけでなく、登壇・執筆・コミュニティ活動からも人物像と影響範囲を理解したい。
+
+**Why this priority**: アウトプットは意思決定/継続性/発信力の証拠で、ポートフォリオの説得力を上げるため。
+
+**Independent Test**: TOC→該当セクションへ移動し、Talks/Books/Community が見つかり、リンクが安全に開く。
+
+**Acceptance Scenarios**:
+
+1. **Given** ポートフォリオを開く、**When** TOCからActivities（または統合セクション）へ移動する、**Then** 一覧が見える
+2. **Given** 各項目にリンクがある、**When** クリックする、**Then** 別タブで安全に開く（`rel="noreferrer"`）
+
+---
+
+### User Story 2 - blogとの情報設計が破綻しない (Priority: P2)
+
+サイトオーナーとして、blog（Writing）と活動（Talks/Books/Community）の住み分けが自然で、TOCが過密にならないようにしたい。
+
+**Why this priority**: 目次の認知負荷が上がると、読み手が迷うため。
+
+**Independent Test**: TOC項目が過剰にならず、WritingとActivitiesの区別が明確。
+
+**Acceptance Scenarios**:
+
+1. **Given** TOCを開く、**When** 一覧を見る、**Then** 8項目以内でスキャンできる
+2. **Given** Writing/Activities がある、**When** それぞれ開く、**Then** 役割（文章 vs 活動）が直感的にわかる
+
+---
+
+### Edge Cases
+
+- Activitiesの項目が0件の場合でもUIが壊れない（“Coming soon” など明示）
+- 外部リンクが一時的に落ちていてもページ自体は壊れない
+- private override 機構を壊さない（このfeatureはpublic側の導線/表示追加）
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Talks/Books/Community を表現できるセクションが存在しなければならない
+- **FR-002**: 各項目は最小限のメタデータ（title/year + optional link）を持てなければならない
+- **FR-003**: 外部リンクは別タブで開き、`rel="noreferrer"` を付与しなければならない
+- **FR-004**: TOC/アンカー移動のUXを壊してはならない（8項目ガイドも考慮）
+- **FR-005**: 既存の `portfolio.writing` と整合する情報設計でなければならない（統合/分離の判断含む）
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 読者が1分以内に「登壇/執筆/コミュニティ活動」の有無と概要を把握できる
+- **SC-002**: `pnpm lint` と `pnpm build` が通る
+
+

--- a/specs/006-activities/tasks.md
+++ b/specs/006-activities/tasks.md
@@ -23,9 +23,9 @@ description: "Tasks for 006 – Activities (Talks / Books / Community)"
 
 **Purpose**: Confirm the integration points for adding a new proof surface + TOC entry.
 
-- [ ] T001 Confirm current TOC config and section composition in `src/components/toc.ts` and `src/app/page.tsx`
-- [ ] T002 Confirm current content source-of-truth patterns and private override merge in `src/content/portfolio.ts`
-- [ ] T003 [P] Confirm external link safety pattern in existing sections (`src/components/sections/WritingSection.tsx`, `src/components/sections/ContactSection.tsx`)
+- [x] T001 Confirm current TOC config and section composition in `src/components/toc.ts` and `src/app/page.tsx`
+- [x] T002 Confirm current content source-of-truth patterns and private override merge in `src/content/portfolio.ts`
+- [x] T003 [P] Confirm external link safety pattern in existing sections (`src/components/sections/WritingSection.tsx`, `src/components/sections/ContactSection.tsx`)
 
 ---
 
@@ -35,10 +35,10 @@ description: "Tasks for 006 – Activities (Talks / Books / Community)"
 
 **⚠️ CRITICAL**: No user story work should begin until this phase is complete.
 
-- [ ] T004 Decide final IA as **split** (Writing vs Activities) and document rationale in `specs/006-activities/research.md`
-- [ ] T005 Add TOC id (`activities`) + label (`Activities`) in `src/components/toc.ts`
-- [ ] T006 Add new section component file `src/components/sections/ActivitiesSection.tsx` (server component, same frame styling)
-- [ ] T007 Wire the section into page composition in `src/app/page.tsx` (keep page thin; choose section order)
+- [x] T004 Decide final IA as **split** (Writing vs Activities) and document rationale in `specs/006-activities/research.md`
+- [x] T005 Add TOC id (`activities`) + label (`Activities`) in `src/components/toc.ts`
+- [x] T006 Add new section component file `src/components/sections/ActivitiesSection.tsx` (server component, same frame styling)
+- [x] T007 Wire the section into page composition in `src/app/page.tsx` (keep page thin; choose section order)
 
 **Checkpoint**: The app compiles and the `#activities` anchor exists.
 
@@ -52,10 +52,10 @@ description: "Tasks for 006 – Activities (Talks / Books / Community)"
 
 ### Implementation for User Story 1
 
-- [ ] T008 [US1] Extend content model and add `portfolio.activities` to `src/content/portfolio.ts` (types + `publicPortfolio` + merge)
-- [ ] T009 [US1] Render grouped items (Talks/Books/Community) in `src/components/sections/ActivitiesSection.tsx`
-- [ ] T010 [US1] Implement explicit empty state (“Coming soon”) when a group has zero items in `src/components/sections/ActivitiesSection.tsx`
-- [ ] T011 [US1] Ensure external links are safe in `src/components/sections/ActivitiesSection.tsx` (`target="_blank"`, `rel="noreferrer"`)
+- [x] T008 [US1] Extend content model and add `portfolio.activities` to `src/content/portfolio.ts` (types + `publicPortfolio` + merge)
+- [x] T009 [US1] Render grouped items (Talks/Books/Community) in `src/components/sections/ActivitiesSection.tsx`
+- [x] T010 [US1] Implement explicit empty state (“Coming soon”) when a group has zero items in `src/components/sections/ActivitiesSection.tsx`
+- [x] T011 [US1] Ensure external links are safe in `src/components/sections/ActivitiesSection.tsx` (`target="_blank"`, `rel="noreferrer"`)
 
 **Checkpoint**: Activities section is scannable in <1 minute and does not leak unsafe links.
 
@@ -69,8 +69,8 @@ description: "Tasks for 006 – Activities (Talks / Books / Community)"
 
 ### Implementation for User Story 2
 
-- [ ] T012 [US2] Add short explanatory copy to `src/components/sections/WritingSection.tsx` and/or `src/components/sections/ActivitiesSection.tsx` so roles are obvious
-- [ ] T013 [US2] Verify TOC count and label scan-ability in `src/components/toc.ts` (no overlong labels)
+- [x] T012 [US2] Add short explanatory copy to `src/components/sections/WritingSection.tsx` and/or `src/components/sections/ActivitiesSection.tsx` so roles are obvious
+- [x] T013 [US2] Verify TOC count and label scan-ability in `src/components/toc.ts` (no overlong labels)
 
 **Checkpoint**: No confusion between Writing and Activities; navigation remains fast.
 
@@ -80,10 +80,10 @@ description: "Tasks for 006 – Activities (Talks / Books / Community)"
 
 **Purpose**: Quality gates + docs sync for top-level UX change.
 
-- [ ] T014 Update docs to mention the new Activities section in `README.md`, `AGENTS.md`, and `CLAUDE.md`
-- [ ] T015 Run `specs/006-activities/quickstart.md` verification steps
-- [ ] T016 Run `pnpm lint` and fix any issues
-- [ ] T017 Run `pnpm build` and fix any issues
+- [x] T014 Update docs to mention the new Activities section in `README.md`, `AGENTS.md`, and `CLAUDE.md`
+- [x] T015 Run `specs/006-activities/quickstart.md` verification steps
+- [x] T016 Run `pnpm lint` and fix any issues
+- [x] T017 Run `pnpm build` and fix any issues
 
 ---
 

--- a/specs/006-activities/tasks.md
+++ b/specs/006-activities/tasks.md
@@ -1,0 +1,114 @@
+---
+description: "Tasks for 006 – Activities (Talks / Books / Community)"
+---
+
+# Tasks: 006 – Activities (Talks / Books / Community)
+
+**Input**: Design documents from `/Users/takeshiwatanabe/EureWorks/private/git/portfolio/specs/006-activities/`  
+**Prerequisites**: `plan.md` (required), `spec.md` (required), `research.md`, `data-model.md`, `contracts/`, `quickstart.md`  
+
+**Tests**: No automated tests requested. Verify via `quickstart.md`, plus `pnpm lint` and `pnpm build`.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and validation.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1/US2)
+- All tasks include exact file paths
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm the integration points for adding a new proof surface + TOC entry.
+
+- [ ] T001 Confirm current TOC config and section composition in `src/components/toc.ts` and `src/app/page.tsx`
+- [ ] T002 Confirm current content source-of-truth patterns and private override merge in `src/content/portfolio.ts`
+- [ ] T003 [P] Confirm external link safety pattern in existing sections (`src/components/sections/WritingSection.tsx`, `src/components/sections/ContactSection.tsx`)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Establish the section + data scaffolding before user story delivery.
+
+**⚠️ CRITICAL**: No user story work should begin until this phase is complete.
+
+- [ ] T004 Decide final IA as **split** (Writing vs Activities) and document rationale in `specs/006-activities/research.md`
+- [ ] T005 Add TOC id (`activities`) + label (`Activities`) in `src/components/toc.ts`
+- [ ] T006 Add new section component file `src/components/sections/ActivitiesSection.tsx` (server component, same frame styling)
+- [ ] T007 Wire the section into page composition in `src/app/page.tsx` (keep page thin; choose section order)
+
+**Checkpoint**: The app compiles and the `#activities` anchor exists.
+
+---
+
+## Phase 3: User Story 1 - 第三者が「アウトプット/社会的活動」を把握できる (Priority: P1) 🎯 MVP
+
+**Goal**: Reader can find talks/books/community and open links safely.
+
+**Independent Test**: TOC → Activities shows groups (Talks/Books/Community). Any external links open in a new tab with `rel="noreferrer"`.
+
+### Implementation for User Story 1
+
+- [ ] T008 [US1] Extend content model and add `portfolio.activities` to `src/content/portfolio.ts` (types + `publicPortfolio` + merge)
+- [ ] T009 [US1] Render grouped items (Talks/Books/Community) in `src/components/sections/ActivitiesSection.tsx`
+- [ ] T010 [US1] Implement explicit empty state (“Coming soon”) when a group has zero items in `src/components/sections/ActivitiesSection.tsx`
+- [ ] T011 [US1] Ensure external links are safe in `src/components/sections/ActivitiesSection.tsx` (`target="_blank"`, `rel="noreferrer"`)
+
+**Checkpoint**: Activities section is scannable in <1 minute and does not leak unsafe links.
+
+---
+
+## Phase 4: User Story 2 - blogとの情報設計が破綻しない (Priority: P2)
+
+**Goal**: Writing vs Activities separation is intuitive and TOC stays within the guideline.
+
+**Independent Test**: TOC has <= 8 items; “Writing = articles” and “Activities = talks/books/community” is clear from headings and copy.
+
+### Implementation for User Story 2
+
+- [ ] T012 [US2] Add short explanatory copy to `src/components/sections/WritingSection.tsx` and/or `src/components/sections/ActivitiesSection.tsx` so roles are obvious
+- [ ] T013 [US2] Verify TOC count and label scan-ability in `src/components/toc.ts` (no overlong labels)
+
+**Checkpoint**: No confusion between Writing and Activities; navigation remains fast.
+
+---
+
+## Phase N: Polish & Cross-Cutting Concerns
+
+**Purpose**: Quality gates + docs sync for top-level UX change.
+
+- [ ] T014 Update docs to mention the new Activities section in `README.md`, `AGENTS.md`, and `CLAUDE.md`
+- [ ] T015 Run `specs/006-activities/quickstart.md` verification steps
+- [ ] T016 Run `pnpm lint` and fix any issues
+- [ ] T017 Run `pnpm build` and fix any issues
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies
+- **Foundational (Phase 2)**: Depends on Setup completion (blocks US1/US2)
+- **US1 (P1)**: Depends on Foundational
+- **US2 (P2)**: Depends on US1 being present (since it’s about IA consistency)
+- **Polish**: After US1/US2
+
+### Parallel Opportunities
+
+- T003 can run in parallel (read-only confirmation across files)
+- After T005–T007, T008 (data model) and T009–T011 (UI) can be parallelized by file
+
+---
+
+## Parallel Example: User Story 1
+
+```text
+Task: "Add activities data model + public data to src/content/portfolio.ts"
+Task: "Implement ActivitiesSection UI in src/components/sections/ActivitiesSection.tsx"
+```
+
+

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import { ProfileSection } from "@/components/sections/ProfileSection";
 import { ProjectsSection } from "@/components/sections/ProjectsSection";
 import { SkillsSection } from "@/components/sections/SkillsSection";
 import { WritingSection } from "@/components/sections/WritingSection";
+import { ActivitiesSection } from "@/components/sections/ActivitiesSection";
 
 export default function Home() {
   return (
@@ -17,6 +18,7 @@ export default function Home() {
         <ExperienceSection />
         <ProjectsSection />
         <WritingSection />
+        <ActivitiesSection />
         <SkillsSection />
         <ContactSection />
       </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,12 @@
 import { Hero } from "@/components/Hero";
 import { TableOfContents } from "@/components/TableOfContents";
+import { ActivitiesSection } from "@/components/sections/ActivitiesSection";
 import { ContactSection } from "@/components/sections/ContactSection";
 import { ExperienceSection } from "@/components/sections/ExperienceSection";
 import { ProfileSection } from "@/components/sections/ProfileSection";
 import { ProjectsSection } from "@/components/sections/ProjectsSection";
 import { SkillsSection } from "@/components/sections/SkillsSection";
 import { WritingSection } from "@/components/sections/WritingSection";
-import { ActivitiesSection } from "@/components/sections/ActivitiesSection";
 
 export default function Home() {
   return (

--- a/src/components/sections/ActivitiesSection.tsx
+++ b/src/components/sections/ActivitiesSection.tsx
@@ -1,0 +1,81 @@
+import { getPortfolio } from "@/content/portfolio";
+
+function isExternalHttpHref(href: string) {
+  return href.startsWith("http://") || href.startsWith("https://");
+}
+
+export async function ActivitiesSection() {
+  const { activities } = await getPortfolio();
+
+  return (
+    <section
+      id={activities.id}
+      className="scroll-mt-6 frame bg-[#1b1b1b] p-6 text-fami-ivory"
+    >
+      <h2
+        className="text-xl text-fami-gold"
+        style={{ fontFamily: "var(--font-press)" }}
+      >
+        {activities.heading}
+      </h2>
+
+      <p className="mt-3 text-sm [font-family:var(--font-noto)]">
+        登壇・執筆・コミュニティ活動をまとめています。
+      </p>
+
+      <div className="mt-5 space-y-6">
+        {activities.groups.map((group) => (
+          <div key={group.name}>
+            <h3
+              className="text-xs uppercase tracking-[0.3em] text-fami-gold"
+              style={{ fontFamily: "var(--font-press)" }}
+            >
+              {group.name}
+            </h3>
+
+            {group.items.length === 0 ? (
+              <p className="mt-3 text-sm [font-family:var(--font-noto)]">
+                Coming soon
+              </p>
+            ) : (
+              <ul className="mt-3 space-y-3 text-sm [font-family:var(--font-noto)]">
+                {group.items.map((item) => (
+                  <li key={`${group.name}:${item.year}:${item.title}`} className="space-y-2">
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span className="nes-badge is-warning text-[0.6rem]">
+                            <span>{item.year}</span>
+                          </span>
+                          <span className="truncate">{item.title}</span>
+                        </div>
+                        {item.context ? (
+                          <p className="mt-1 text-xs text-fami-ivory/90">
+                            {item.context}
+                          </p>
+                        ) : null}
+                      </div>
+
+                      {item.link ? (
+                        <a
+                          className="nes-btn is-small shrink-0"
+                          href={item.link.href}
+                          target={isExternalHttpHref(item.link.href) ? "_blank" : undefined}
+                          rel={isExternalHttpHref(item.link.href) ? "noreferrer" : undefined}
+                        >
+                          {item.link.label}
+                        </a>
+                      ) : null}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+

--- a/src/components/sections/WritingSection.tsx
+++ b/src/components/sections/WritingSection.tsx
@@ -19,7 +19,7 @@ export async function WritingSection() {
       </h2>
 
       <p className="mt-3 text-sm [font-family:var(--font-noto)]">
-        技術記事と雑記を分けて書いています。
+        記事（Writing）は文章のまとめ。登壇/書籍/コミュニティは Activities に分けています。
       </p>
 
       <div className="mt-6 flex flex-wrap gap-3">

--- a/src/components/toc.ts
+++ b/src/components/toc.ts
@@ -3,6 +3,7 @@ export type TocItemId =
   | "experience"
   | "projects"
   | "writing"
+  | "activities"
   | "skills"
   | "contact";
 
@@ -16,6 +17,7 @@ export const TOC_ITEMS: TocItem[] = [
   { id: "experience", label: "Experience" },
   { id: "projects", label: "Projects" },
   { id: "writing", label: "Writing" },
+  { id: "activities", label: "Activities" },
   { id: "skills", label: "Skills" },
   { id: "contact", label: "Contact" },
 ];

--- a/src/content/portfolio.ts
+++ b/src/content/portfolio.ts
@@ -204,9 +204,16 @@ export const publicPortfolio: Portfolio = {
     id: "activities",
     heading: "Activities",
     groups: [
-      { name: "Talks", items: [] },
-      { name: "Books", items: [] },
-      { name: "Community", items: [] },
+      { name: "Talks",
+        items: [
+        { year: "2020", title: "AWS Partner Summit Tokyo", context: "AWS Partner Summit Tokyoにオンラインで登壇しました", link: { label: "開催記事", href: "https://aws.amazon.com/jp/blogs/psa/aws-partner-summit-tokyo/" } },
+      ] },
+      { name: "Books", items: [
+        { year: "2025", title: "Tech Blog", context: "Medium", link: { label: "Medium", href: "https://medium.com/@buzz_tkc" } },
+      ] },
+      { name: "Community", items: [
+        { year: "2025", title: "Tech Blog", context: "Medium", link: { label: "Medium", href: "https://medium.com/@buzz_tkc" } },
+      ] },
     ],
   },
   skills: {
@@ -256,13 +263,7 @@ export const publicPortfolio: Portfolio = {
     id: "contact",
     heading: "Contact",
     blurb:
-      "採用・協業・技術相談など、目的に合わせてご連絡ください。\n\n" +
-      "連絡してほしい内容の例:\n" +
-      "・Backend/Infra の設計・実装・運用改善\n" +
-      "・既存システムの段階移行（リプレース/移行設計/リスク管理）\n" +
-      "・Observability（Datadog等）/SLO/障害対応の仕組み化\n" +
-      "・TypeScript のフルスタック開発\n\n" +
-      "返信目安: 24–48時間以内（状況により前後します）",
+      "副業・技術相談など、お気軽にご連絡ください。",
     links: [
       { label: "Email", href: "worktkc2018@gmail.com" },
       { label: "X / Twitter", href: "https://x.com/buzz_tkc" },

--- a/src/content/portfolio.ts
+++ b/src/content/portfolio.ts
@@ -64,6 +64,20 @@ export type Experience = SectionContent & { highlights: ExperienceHighlight[] };
 export type Projects = SectionContent & { items: Project[] };
 export type Skills = SectionContent & { items: Skill[]; categories?: SkillCategory[] };
 export type Writing = SectionContent & { items: ExternalLink[] };
+
+export type ActivityItem = {
+  year: string;
+  title: string;
+  context?: string;
+  link?: ExternalLink;
+};
+
+export type ActivityGroup = {
+  name: "Talks" | "Books" | "Community";
+  items: ActivityItem[];
+};
+
+export type Activities = SectionContent & { groups: ActivityGroup[] };
 export type Contact = SectionContent & { blurb: string; links: ExternalLink[] };
 
 export type Portfolio = {
@@ -71,6 +85,7 @@ export type Portfolio = {
   experience: Experience;
   projects: Projects;
   writing: Writing;
+  activities: Activities;
   skills: Skills;
   contact: Contact;
 };
@@ -185,6 +200,15 @@ export const publicPortfolio: Portfolio = {
       { label: "Casual (sizu.me)", href: "https://sizu.me/buzz" },
     ],
   },
+  activities: {
+    id: "activities",
+    heading: "Activities",
+    groups: [
+      { name: "Talks", items: [] },
+      { name: "Books", items: [] },
+      { name: "Community", items: [] },
+    ],
+  },
   skills: {
     id: "skills",
     heading: "Skills",
@@ -270,6 +294,7 @@ function isPortfolioPatch(value: unknown): value is Partial<Portfolio> {
     "experience" in value ||
     "projects" in value ||
     "writing" in value ||
+    "activities" in value ||
     "skills" in value ||
     "contact" in value
   );
@@ -282,6 +307,7 @@ function mergePortfolio(base: Portfolio, patch: Partial<Portfolio>): Portfolio {
     experience: { ...base.experience, ...(patch.experience ?? {}) },
     projects: { ...base.projects, ...(patch.projects ?? {}) },
     writing: { ...base.writing, ...(patch.writing ?? {}) },
+    activities: { ...base.activities, ...(patch.activities ?? {}) },
     skills: { ...base.skills, ...(patch.skills ?? {}) },
     contact: { ...base.contact, ...(patch.contact ?? {}) },
   };
@@ -433,5 +459,6 @@ export const profile = publicPortfolio.profile;
 export const experience = publicPortfolio.experience;
 export const projects = publicPortfolio.projects;
 export const writing = publicPortfolio.writing;
+export const activities = publicPortfolio.activities;
 export const skills = publicPortfolio.skills;
 export const contact = publicPortfolio.contact;

--- a/src/content/portfolio.ts
+++ b/src/content/portfolio.ts
@@ -206,21 +206,22 @@ export const publicPortfolio: Portfolio = {
     groups: [
       { name: "Talks",
         items: [
-        { year: "2020", title: "AWS Partner Summit Tokyo", context: "AWS Partner Summit Tokyoにオンラインで登壇しました", link: { label: "開催記事", href: "https://aws.amazon.com/jp/blogs/psa/aws-partner-summit-tokyo/" } },
+        { year: "2020", title: "AWS Partner Summit Tokyo", context: "AWS Partner Summit TokyoにAWS ANGEL DOJOでアライアンス賞を受賞したプロダクトを紹介しました", link: { label: "開催記事", href: "https://aws.amazon.com/jp/blogs/psa/aws-partner-summit-tokyo/" } },
+        { year: "2024", title: "Developpers Summit", context: "Developper Summit TokyoにPlatform Engineeringについてオフラインで登壇しました", link: { label: "イベント詳細", href: "https://event.shoeisha.jp/devsumi/20240215/session/4807" } },
       ] },
       { name: "Books", items: [
-        { year: "2025", title: "Tech Blog", context: "Medium", link: { label: "Medium", href: "https://medium.com/@buzz_tkc" } },
+        { year: "2024", title: "Real World Platform Engineering: 現場の知恵とノウハウ", context: "Platform Engineeringの現場でのノウハウや導入についてMeetup メンバーで書籍を執筆し、技術書典と技書博で発売しました。", link: { label: "技術書典", href: "https://techbookfest.org/product/qunTLHG5hLbL91bBX9dqDU?productVariantID=diV811bQsBeU5YfWhtGym0" },}
       ] },
       { name: "Community", items: [
-        { year: "2025", title: "Tech Blog", context: "Medium", link: { label: "Medium", href: "https://medium.com/@buzz_tkc" } },
+        { year: "2024", title: "Platform Engineering Kaigi Core Staff", context: "日本初となるPlatform Engineeringに関するカンファレンス開催に貢献しました。", link: { label: "Platform Engineering Kaigi", href: "https://www.cnia.io/pek2024/" } },
+        { year: "2019-2025", title: "SRE NEXT Core Staff", context: "SRE NEXT Core Staffとして、SNS、 会場、 スポンサー、 司会等を担当しました。", link: { label: "SRE NEXT", href: "https://sre-next.dev/" } },
+        { year: "2022-2025", title: "Cloud Native Days Core Staff", context: "Cloud Native Daysの配信担当としてハイブリッドイベント開催に貢献しました。", link: { label: "Cloud Native Days", href: "https://cloudnativedays.jp/" } },
       ] },
     ],
   },
   skills: {
     id: "skills",
     heading: "Skills",
-    // Backward-compatible: keep `items` but do not manually maintain it.
-    // It will be derived from categories by `normalizeSkills()`.
     items: [],
     categories: [
       {


### PR DESCRIPTION
ポートフォリオに Activities（登壇/書籍/コミュニティ） セクションを追加し、TOC から遷移できるようにしました。アウトプット（Writing）と社会的活動（Activities）を分離して、読み手が迷わない情報設計にしています。