### PR TITLE
Dev: disable private content fetch cache

### DIFF
--- a/specs/002-portfolio-private-content/quickstart.md
+++ b/specs/002-portfolio-private-content/quickstart.md
@@ -78,8 +78,10 @@ Set:
 ## 4) Verify behavior
 
 1. Open the site and confirm Experience/Projects reflect sheet values.
-2. Change a sheet row and confirm it **does not** update immediately (cache).
-3. To force fast iteration temporarily, set:
+2. Change a sheet row and confirm it updates as expected:
+   - **Local development (`pnpm dev`)**: should update on the next normal browser reload (no fetch cache in dev).
+   - **Production/Vercel**: may not update immediately (cache window).
+3. If you need faster iteration outside local dev (e.g., production-like runs), set:
    - `PORTFOLIO_PRIVATE_REVALIDATE_SECONDS=0`
 
 ### Quick API test (local)

--- a/specs/012-local-dev-no-fetch-cache/checklists/requirements.md
+++ b/specs/012-local-dev-no-fetch-cache/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Local Dev Experience Freshness
+  
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2025-12-26  
+**Feature**: `specs/012-local-dev-no-fetch-cache/spec.md`
+  
+## Content Quality
+  
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+  
+## Requirement Completeness
+  
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+  
+## Feature Readiness
+  
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+  
+## Notes
+  
+- Dependencies/assumptions are intentionally minimal and documented in the spec’s “Assumptions” section: the spec treats “Experience data source” generically and scopes changes to “local development mode” only, preserving production behavior.

--- a/specs/012-local-dev-no-fetch-cache/contracts/README.md
+++ b/specs/012-local-dev-no-fetch-cache/contracts/README.md
@@ -1,0 +1,39 @@
+# Contracts: Private Portfolio Patch Endpoint (Experience data source)
+
+**Feature**: `specs/012-local-dev-no-fetch-cache/spec.md`  
+**Date**: 2025-12-26
+
+## Purpose
+
+Define the expectations for the external “Experience data source” endpoint used to load private
+portfolio overrides (including Experience and Projects) without committing private content.
+
+This contract is intentionally lightweight: it documents *what* the endpoint must do, not the
+implementation.
+
+## Endpoint behavior
+
+- **Request**:
+  - The system initiates a request to an “execute” URL.
+  - The execute request is a **POST** with a JSON body.
+  - A bearer token may be provided (e.g., for private spreadsheets); transport details are an implementation choice.
+
+- **Redirects**:
+  - The execute endpoint may respond with redirects to a content URL.
+  - The client follows redirects with **GET** to retrieve the final JSON content.
+
+- **Response**:
+  - Final response must be **JSON**.
+  - Shape is a **partial portfolio patch** (only the fields that need overriding).
+  - If the response is invalid or cannot be fetched within a timeout, the site must fall back to public content.
+
+## Example patch scope (non-exhaustive)
+
+- `experience`: heading + timeline items
+- `projects`: items that are used by Experience’s “Evidence” linking
+
+## Non-goals
+
+- This contract does not define cache headers.
+- This contract does not require a particular hosting provider or spreadsheet mechanism.
+

--- a/specs/012-local-dev-no-fetch-cache/data-model.md
+++ b/specs/012-local-dev-no-fetch-cache/data-model.md
@@ -1,0 +1,46 @@
+# Data Model: Local Dev Experience Freshness
+
+**Feature**: `specs/012-local-dev-no-fetch-cache/spec.md`  
+**Date**: 2025-12-26
+
+## Key entities
+
+- **Portfolio (public)**: The baseline, committed content shipped with the repo.
+- **Portfolio Patch (private override)**: Optional overrides loaded at runtime and merged into the public portfolio.
+- **Experience Section**: The content rendered by `ExperienceSection`, sourced from the merged portfolio.
+- **Experience Highlight**: A single timeline item rendered in Experience (e.g., `{ year, text }`).
+- **Projects Section (supporting)**: Used by Experience to link “Evidence” strings to project anchors.
+- **Experience Data Source**: The external canonical source for Experience (currently a spreadsheet-backed endpoint).
+- **Runtime Mode**: Development vs production mode, used to apply different freshness policies.
+
+## Relationships / flow
+
+```text
+Experience Data Source
+   │
+   ├─(fetch / parse)─> Portfolio Patch (private override)
+   │                      │
+   │                      ├─(merge)─> Portfolio (merged)
+   │                      │             │
+   │                      │             └─> Experience Section / Projects Section render
+   │                      │
+   │                      └─(freshness policy depends on Runtime Mode)
+   │
+Public Portfolio (committed)
+```
+
+## Freshness policy (by runtime mode)
+
+- **Development**:
+  - Freshness is prioritized: the next page reload should reflect the latest data source state.
+  - Caching for the private patch retrieval path is disabled.
+
+- **Production**:
+  - Existing caching behavior remains in effect (revalidate-based window).
+  - The feature must not broaden its scope to force “always fresh” production behavior.
+
+## External data notes (high level)
+
+- The private patch endpoint returns a JSON object that can partially override portfolio fields (e.g., Experience and Projects).
+- The patch is validated before merging; invalid patches are ignored and the site falls back to public content.
+

--- a/specs/012-local-dev-no-fetch-cache/plan.md
+++ b/specs/012-local-dev-no-fetch-cache/plan.md
@@ -1,0 +1,125 @@
+# Implementation Plan: Local Dev Experience Freshness
+
+**Branch**: `012-local-dev-no-fetch-cache` | **Date**: 2025-12-26 | **Spec**: `specs/012-local-dev-no-fetch-cache/spec.md`  
+**Input**: Feature specification from `specs/012-local-dev-no-fetch-cache/spec.md`
+
+## Summary
+
+Make local development always reflect the latest Experience spreadsheet changes on a normal browser
+reload, by disabling data caching in development *only*. Preserve the existing production caching
+behavior (driven by the current revalidate window).
+
+## Technical Context
+
+**Language/Version**: TypeScript (5.x), Node.js >= 20.9.0  
+**Primary Dependencies**: Next.js 16 (App Router), React 19, Tailwind CSS, NES.css  
+**Storage**: N/A (content is in-repo + optional private patch from env/url)  
+**Testing**: No automated tests currently; rely on `pnpm lint` and `pnpm build`  
+**Target Platform**: Vercel (deploy on `main`), local dev via `pnpm dev`  
+**Project Type**: Web application (single Next.js project under `src/`)  
+**Performance Goals**: Production remains fast/stable; local dev prioritizes freshness  
+**Constraints**: No new dependencies; no UI/IA changes; production caching policy must remain unchanged  
+**Scale/Scope**: Small, localized change in the private content loading path used by Experience and other sections
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Personality-First Storytelling**: No narrative/content change; only dev workflow improvement.
+- **II. Retro Aesthetic, Modern Usability**: No UI changes; nothing that degrades usability.
+- **III. Content Is a Product Surface**: Improves iteration speed so content can be refined; no placeholders introduced.
+- **IV. Lightweight, Fast, and Durable**: Avoids new deps and keeps prod caching intact; dev-only bypass is minimal.
+- **V. One Source of Truth, Kept in Sync**: No changes to dependencies/scripts/deploy/top-level UX expected → docs sync not required.
+
+**Quality gates**:
+
+- `pnpm lint`
+- `pnpm build`
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/012-local-dev-no-fetch-cache/
+├── plan.md              # This file (/speckit.plan output)
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   └── README.md        # Phase 1 output (external data expectations)
+└── tasks.md             # Phase 2 output (/speckit.tasks output)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── app/
+│   ├── layout.tsx
+│   ├── page.tsx
+│   └── globals.css
+├── content/
+│   └── portfolio.ts              # getPortfolio() + private patch loading/caching logic
+└── components/
+    └── sections/
+        ├── ExperienceSection.tsx # consumes getPortfolio() and renders Experience
+        └── ... other sections ...# also consume getPortfolio()
+```
+
+**Structure Decision**: Single Next.js App Router project. Implement the dev-only freshness change at
+the centralized private content fetch/caching layer (`src/content/portfolio.ts`) so sections remain unchanged.
+
+## Phase 0 — Outline & Research
+
+**Goal**: Decide the least invasive, Next.js-aligned approach to disable caching for the private patch in local dev only.
+
+Research questions (no NEEDS CLARIFICATION expected):
+
+- How Next.js data cache / request memoization interacts with `unstable_cache` and `fetch` options in development
+- Best practice patterns for “dev only no-store” while keeping production caching (revalidate) unchanged
+
+**Output**: `specs/012-local-dev-no-fetch-cache/research.md`
+
+## Phase 1 — Design & Contracts
+
+**Data model**:
+
+- Describe the “Experience Data Source → Portfolio Patch → Experience Entries” flow and how “runtime mode” affects freshness.
+
+**Contract**:
+
+- Document external expectations for the private patch endpoint (response format, redirects, timeout assumptions) at a high level.
+
+**Quickstart**:
+
+- Document the local workflow to validate: edit spreadsheet → reload → observe updated Experience.
+
+**Output**:
+
+- `specs/012-local-dev-no-fetch-cache/data-model.md`
+- `specs/012-local-dev-no-fetch-cache/contracts/README.md`
+- `specs/012-local-dev-no-fetch-cache/quickstart.md`
+
+## Phase 1 — Agent Context Update
+
+Run:
+
+- `.specify/scripts/bash/update-agent-context.sh cursor-agent`
+
+## Re-check Constitution (post-design)
+
+Confirm:
+
+- No production perf regression (dev-only behavior)
+- No new deps
+- No UI changes
+
+## Phase 2 — Task Planning (handoff to /speckit.tasks)
+
+Implementation tasks will focus on:
+
+- Detecting development runtime
+- Bypassing `unstable_cache` (or forcing revalidate=0) in development only
+- Ensuring underlying `fetch` calls do not return stale content in development
+- Verifying production retains existing cache window behavior

--- a/specs/012-local-dev-no-fetch-cache/quickstart.md
+++ b/specs/012-local-dev-no-fetch-cache/quickstart.md
@@ -1,0 +1,41 @@
+# Quickstart: Verify “always fresh Experience” in local development
+
+## Goal
+
+In **local development only**, after you edit the Experience spreadsheet (data source), a normal browser
+reload should show the updated Experience content immediately—without server restarts, incognito, or hard reloads.
+
+Production behavior must remain unchanged.
+
+## Prerequisites
+
+- You already have a working private content endpoint (spreadsheet-backed) that returns a portfolio patch JSON.
+- Local environment variables are set so the app loads private content from that endpoint.
+
+## Steps (local dev)
+
+1. Start the app:
+
+   - `pnpm dev`
+
+2. Load the page and note the current Experience content.
+
+3. Edit the Experience spreadsheet (e.g., change a timeline item text).
+
+4. Reload the page normally.
+
+5. Confirm the Experience section reflects the edit on that reload.
+
+## Safety check (production-like)
+
+1. Run:
+
+   - `pnpm build`
+   - `pnpm start`
+
+2. Confirm the site still follows the existing production freshness policy (it should not be forced into “always fresh” mode by this feature).
+
+## Troubleshooting
+
+- If you edit Apps Script code (not the spreadsheet data), ensure the Web App is redeployed; otherwise it may serve older code.
+

--- a/specs/012-local-dev-no-fetch-cache/research.md
+++ b/specs/012-local-dev-no-fetch-cache/research.md
@@ -1,0 +1,48 @@
+# Research: Local Dev Experience Freshness
+
+**Feature**: `specs/012-local-dev-no-fetch-cache/spec.md`  
+**Date**: 2025-12-26
+
+## Context
+
+The portfolio loads optional “private content” patches via `getPortfolio()` in `src/content/portfolio.ts`.
+Experience (and other sections) consume `getPortfolio()` from Server Components. Today, the private patch
+loader uses `unstable_cache(..., { revalidate })` to cache the resolved patch for a configured window.
+
+In local development, this caching can make spreadsheet-driven Experience edits feel “stuck” until caches
+expire or the process/browser is restarted.
+
+## Decision
+
+**In local development mode, disable caching for the private patch retrieval path.**
+
+Concretely:
+
+- **Bypass** the `unstable_cache(...)` wrapper in development (call the underlying fetch function directly), and/or
+- Force the cache window to “no caching” in development (e.g., treat `revalidate` as `0`), and
+- Ensure the underlying GET requests are not served from stale caches in development.
+
+## Rationale
+
+- Meets the spec’s primary goal: “edit Experience data source → normal reload shows change.”
+- Centralized: private patch logic lives in one place, minimizing surface area and risk.
+- Production safety: keep existing `revalidate` behavior unchanged outside development.
+- Lightweight: no new dependencies, no UI changes.
+
+## Alternatives considered
+
+- **Set `PORTFOLIO_PRIVATE_REVALIDATE_SECONDS=0` locally**:
+  - Pros: simple configuration.
+  - Cons: still an extra manual step; easy to forget; does not guarantee underlying request freshness.
+- **Cache-busting query params** on the content URL:
+  - Pros: strong freshness.
+  - Cons: leaks into logs/URLs; could interact badly with redirect chains; more invasive.
+- **Global “force dynamic” at page level**:
+  - Pros: simple.
+  - Cons: broader blast radius than needed; can affect other content/sections unnecessarily.
+
+## Notes / Implementation guidance
+
+- Prefer the smallest change point: `src/content/portfolio.ts` where `unstable_cache` is applied.
+- Keep “production behavior unchanged” as a hard gate.
+

--- a/specs/012-local-dev-no-fetch-cache/spec.md
+++ b/specs/012-local-dev-no-fetch-cache/spec.md
@@ -1,0 +1,99 @@
+# Feature Specification: Local Dev Experience Freshness
+
+**Feature Branch**: `012-local-dev-no-fetch-cache`  
+**Created**: 2025-12-26  
+**Status**: Draft  
+**Input**: User description: "ローカル開発だけ変更をすぐに確認したいので、fetchのcacheはなしにしてほしい。"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - See Experience updates immediately in local dev (Priority: P1)
+
+As the site owner/developer, when I edit the Experience spreadsheet (the Experience data source),
+I want to refresh the local site and immediately see the updated Experience content so I can iterate
+quickly without fighting stale cached data.
+
+**Why this priority**: This is the primary pain point blocking fast iteration on Experience content.
+
+**Independent Test**: Start local development, change the Experience data source, reload the page,
+and verify the Experience section reflects the change without any extra manual steps.
+
+**Acceptance Scenarios**:
+
+1. **Given** the site is running in local development mode, **When** the Experience data source changes and I reload the page, **Then** the Experience section shows the updated content on that reload.
+2. **Given** the site is running in local development mode, **When** I navigate away and back (or reload) after an Experience data source change, **Then** I do not see stale Experience content from an old cached response.
+
+---
+
+### User Story 2 - Production visitors keep fast loads (Priority: P2)
+
+As a production visitor, I want the site to remain fast and stable. This change must not accidentally
+disable caching in production and cause unnecessary performance regressions.
+
+**Why this priority**: The portfolio is user-facing; performance regressions are user-visible bugs.
+
+**Independent Test**: Build/run in a production-like mode and confirm the “always fresh on every
+reload” behavior is not forced on (i.e., this feature is limited to local development).
+
+**Acceptance Scenarios**:
+
+1. **Given** the site is running in production mode, **When** the Experience data source changes, **Then** the site continues to behave according to the existing production freshness/caching policy (this feature does not override it).
+
+---
+
+### User Story 3 - No workflow hacks needed (Priority: P3)
+
+As the site owner/developer, I want a simple workflow where I can confirm Experience edits without
+having to restart the dev server, open incognito, or do a hard reload.
+
+**Why this priority**: Reduces friction and makes content iteration sustainable.
+
+**Independent Test**: After a data source change, confirm that a normal browser reload is sufficient
+to observe the updated Experience content in local development.
+
+**Acceptance Scenarios**:
+
+1. **Given** local development mode, **When** the Experience data source changes, **Then** a normal browser reload (not a hard reload) is sufficient to see the updated Experience content.
+
+---
+
+### Edge Cases
+
+- **Data source temporarily unavailable**: the page should still render and make it clear Experience content may be missing/stale.
+- **Data source returns invalid/unexpected data**: the site should not crash; Experience should fail gracefully.
+- **Rapid consecutive edits**: repeated reloads should always reflect the latest available data in local development mode.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: In local development mode, the system MUST not show stale Experience content due to cached data source responses.
+- **FR-002**: In local development mode, after the Experience data source changes, the system MUST show updated Experience content on the next normal browser reload.
+- **FR-003**: In production mode, the system MUST preserve the existing Experience freshness/caching behavior (this feature MUST be scoped to local development only).
+- **FR-004**: This feature MUST NOT change the visual layout, information architecture, or public content structure; it only affects local development freshness.
+
+### Key Entities *(include if feature involves data)*
+
+- **Experience Data Source**: A canonical external source of Experience entries (currently edited outside the repo).
+- **Experience Entry**: A single record rendered in the Experience section (e.g., role, company/project, dates, summary).
+- **Runtime Mode**: Whether the site is running in local development mode or production mode.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: In local development mode, after updating the Experience data source, the updated Experience content is visible within one normal browser reload.
+- **SC-002**: In local development mode, developers do not need workarounds (server restart, incognito, hard reload) to observe updated Experience content.
+- **SC-003**: In production mode, the portfolio’s perceived load speed and stability does not regress due to this change (no new “always refresh” behavior applied to visitors).
+
+## Assumptions
+
+- The portfolio has a single canonical Experience data source that is fetched/rendered for the Experience section.
+- The runtime can reliably distinguish “local development mode” from “production mode.”
+- The developer confirms freshness by editing the Experience data source and reloading the page.
+
+## Out of Scope
+
+- Changing Experience content structure, copy, or design.
+- Changing the production freshness/caching policy (this feature is scoped to local development only).
+- Introducing new content pipelines, authentication, or long-running services.

--- a/specs/012-local-dev-no-fetch-cache/tasks.md
+++ b/specs/012-local-dev-no-fetch-cache/tasks.md
@@ -1,0 +1,124 @@
+# Tasks: Local Dev Experience Freshness
+
+**Input**: Design documents from `specs/012-local-dev-no-fetch-cache/`  
+**Prerequisites**: `plan.md` (required), `spec.md` (required), `research.md`, `data-model.md`, `contracts/`, `quickstart.md`
+
+**Tests**: Not requested in the feature spec. Validation will rely on `pnpm lint`, `pnpm build`, and the manual verification steps in `specs/012-local-dev-no-fetch-cache/quickstart.md`.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Align on current behavior and the minimal change point (centralized private patch loading).
+
+- [x] T001 Confirm current caching behavior and change point in `src/content/portfolio.ts` (private patch uses `unstable_cache` with `revalidate`)
+- [x] T002 [P] Confirm Experience consumes private patch via `getPortfolio()` in `src/components/sections/ExperienceSection.tsx`
+- [x] T003 [P] Review private-content workflow constraints in `specs/002-portfolio-private-content/quickstart.md` (spreadsheet/apps script + existing cache guidance)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Implement a safe “dev-only freshness policy” primitive that all user stories rely on.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [x] T004 Add a runtime-mode helper (development vs production) in `src/content/portfolio.ts`
+- [x] T005 Refactor the private patch fetch helpers to support dev-only fetch options in `src/content/portfolio.ts`
+- [x] T006 In development mode, bypass `unstable_cache` and call the private patch fetcher directly in `src/content/portfolio.ts`
+- [x] T007 In development mode, ensure the redirect-following GET fetch is not served from stale cache (e.g., `no-store`) in `src/content/portfolio.ts`
+- [x] T008 Verify fallback behavior remains unchanged on fetch/parse failure in `src/content/portfolio.ts` (must fall back to public portfolio)
+
+**Checkpoint**: Foundation ready — local dev can fetch fresh private patches; production path remains unchanged by default
+
+---
+
+## Phase 3: User Story 1 — See Experience updates immediately in local dev (Priority: P1) 🎯 MVP
+
+**Goal**: Spreadsheet edits to Experience are visible on the next normal reload in local development.
+
+**Independent Test**: Follow `specs/012-local-dev-no-fetch-cache/quickstart.md` steps (edit spreadsheet → normal reload → Experience reflects changes).
+
+### Implementation for User Story 1
+
+- [x] T009 [US1] Ensure Experience reflects the latest private patch on normal reload in local dev by adjusting private patch loading in `src/content/portfolio.ts`
+- [x] T010 [US1] Add/adjust inline documentation explaining dev-only freshness vs production caching in `src/content/portfolio.ts`
+- [x] T011 [US1] Validate the user journey with the manual steps in `specs/012-local-dev-no-fetch-cache/quickstart.md`
+
+**Checkpoint**: User Story 1 is fully functional and independently verifiable in local dev
+
+---
+
+## Phase 4: User Story 2 — Production visitors keep fast loads (Priority: P2)
+
+**Goal**: Production behavior stays on the existing caching policy (revalidate-based window); no “always fresh” is forced.
+
+**Independent Test**: Run `pnpm build` + `pnpm start` and confirm the site operates normally and the production path still uses the existing caching window behavior.
+
+### Implementation for User Story 2
+
+- [x] T012 [US2] Confirm non-development runtime continues to use `unstable_cache(..., { revalidate })` in `src/content/portfolio.ts`
+- [x] T013 [US2] Run the production-like safety check steps in `specs/012-local-dev-no-fetch-cache/quickstart.md`
+
+**Checkpoint**: Production-like run passes; no unintended “always fresh” behavior is introduced
+
+---
+
+## Phase 5: User Story 3 — No workflow hacks needed (Priority: P3)
+
+**Goal**: Developers don’t need to restart dev server/incognito/hard reload to see Experience updates.
+
+**Independent Test**: In local dev, a normal reload is sufficient after a spreadsheet edit.
+
+### Implementation for User Story 3
+
+- [x] T014 [US3] Update documentation to remove “workaround” guidance for local dev (keep production cache guidance) in `specs/002-portfolio-private-content/quickstart.md`
+
+**Checkpoint**: Docs reflect the new dev workflow; no hacks required
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Ensure quality gates pass and docs remain accurate.
+
+- [x] T015 Run `pnpm lint` and fix any issues caused by changes in `src/content/portfolio.ts`
+- [x] T016 Run `pnpm build` and fix any issues caused by changes in `src/content/portfolio.ts`
+- [x] T017 Run through `specs/012-local-dev-no-fetch-cache/quickstart.md` end-to-end and confirm it matches observed behavior
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion — BLOCKS all user stories
+- **User Stories (Phase 3–5)**: Depend on Foundational completion
+- **Polish (Phase 6)**: Depends on completing the desired user stories (at minimum US1)
+
+### User Story Dependencies
+
+- **US1 (P1)**: Starts after Phase 2, no dependency on US2/US3
+- **US2 (P2)**: Starts after Phase 2, validates production safety of the Phase 2 changes
+- **US3 (P3)**: Starts after US1 (docs/workflow confirmation)
+
+### Parallel Opportunities
+
+- Phase 1 tasks marked **[P]** can run in parallel
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational
+3. Complete Phase 3: US1
+4. Validate with `specs/012-local-dev-no-fetch-cache/quickstart.md`
+
+### Incremental Delivery
+
+1. Add US1 → validate dev freshness
+2. Add US2 → validate production safety
+3. Add US3 → update documentation for the new dev workflow
+


### PR DESCRIPTION
## What
- In local dev only, bypass cached private patch loading so spreadsheet edits show up on normal reload.
- Keep production caching behavior unchanged.

## Changes
- `src/content/portfolio.ts`: dev-only `cache: "no-store"` + bypass `unstable_cache`
- `specs/002-portfolio-private-content/quickstart.md`: clarify dev vs prod behavior
- `specs/012-local-dev-no-fetch-cache/*`: spec/plan/tasks artifacts

## Verification
- `pnpm lint`
- `pnpm build`
- Manual: edit Experience sheet -> reload -> updated content
