### PR TITLE
Content: Experience/Projects brush-up

### DIFF
--- a/specs/013-exp-projects-brushup/contracts/README.md
+++ b/specs/013-exp-projects-brushup/contracts/README.md
@@ -1,0 +1,42 @@
+# Contracts: Evidence format and linking (Experience → Projects)
+
+**Feature**: `specs/013-exp-projects-brushup/spec.md`  
+**Date**: 2025-12-26
+
+## Purpose
+
+Define the supported “Evidence” reference formats embedded in Experience text and how they resolve
+to in-page Project anchors.
+
+This contract is intentionally minimal and backwards-compatible.
+
+## Current format (supported)
+
+- Experience item text may include an Evidence suffix using the delimiter:
+  - ` / Evidence: `
+- Everything after the delimiter is treated as the Evidence reference string.
+
+Example:
+
+- `... / Evidence: Goによるバックエンド刷新`
+
+## Matching rules (supported)
+
+When resolving Evidence to a Project:
+
+- The system SHOULD normalize whitespace on both Evidence text and Project title:
+  - Trim leading/trailing whitespace
+  - Collapse runs of whitespace (spaces/tabs/newlines) into a single space
+- If a match is found against a Project title, the link target is that Project’s `anchorId`.
+- If no match is found, Evidence renders as plain text (non-clickable).
+
+## Optional format (supported if implemented)
+
+- If Evidence begins with `#`, treat it as a direct in-page anchor reference:
+  - ` / Evidence: #project-go-migration`
+
+## Non-goals
+
+- No HTML parsing of spreadsheet content
+- No changes to the underlying private content endpoint contract in this feature
+

--- a/specs/013-exp-projects-brushup/data-model.md
+++ b/specs/013-exp-projects-brushup/data-model.md
@@ -1,0 +1,34 @@
+# Data Model: Experience & Projects Brush-up
+
+**Feature**: `specs/013-exp-projects-brushup/spec.md`  
+**Date**: 2025-12-26
+
+## Entities
+
+- **ExperienceHighlight**
+  - Fields: `year: string`, `text: string`
+  - Notes: `text` may include an Evidence hint that refers to a Project.
+
+- **Project**
+  - Fields (relevant): `title: string`, `anchorId?: string`
+  - Notes: `anchorId` is used as the in-page `id` for linking.
+
+- **EvidenceReference** (derived)
+  - Extracted from `ExperienceHighlight.text`
+  - Can resolve to a Project by:
+    - Project title (normalized match), or
+    - Direct `#anchorId` reference (optional enhancement)
+
+## Relationships / navigation
+
+```text
+ExperienceHighlight.text
+  └─(parse)─> EvidenceReference (string)
+              ├─(match by title)─────> Project.anchorId
+              └─(match by #anchorId)─> Project.anchorId
+```
+
+## Invariants
+
+- Project `anchorId` values must remain stable once published (deep links).
+- If EvidenceReference cannot be resolved, it must render as plain text (non-clickable).

--- a/specs/013-exp-projects-brushup/plan.md
+++ b/specs/013-exp-projects-brushup/plan.md
@@ -1,0 +1,117 @@
+# Implementation Plan: Experience & Projects Content Brush-up
+
+**Branch**: `013-exp-projects-brushup` | **Date**: 2025-12-26 | **Spec**: `specs/013-exp-projects-brushup/spec.md`  
+**Input**: Feature specification from `specs/013-exp-projects-brushup/spec.md`
+
+## Summary
+
+Brush up Experience/Projects content rendering and cross-linking:
+
+- Make Experience year label more readable.
+- Preserve spreadsheet line breaks in Experience text.
+- Make Evidence linking reliably navigate to the correct Project (resilient to whitespace/format differences).
+
+## Technical Context
+
+**Language/Version**: TypeScript (5.x), Node.js >= 20.9.0  
+**Primary Dependencies**: Next.js 16 (App Router), React 19, Tailwind CSS, NES.css  
+**Storage**: N/A (content is in-repo + optional private patch via env/url)  
+**Testing**: No automated tests currently; rely on `pnpm lint` and `pnpm build`  
+**Target Platform**: Vercel (deploy on `main`), local dev via `pnpm dev`  
+**Project Type**: Web application (single Next.js project under `src/`)  
+**Performance Goals**: No regressions; changes are render-time only, minimal additional logic  
+**Constraints**: No new dependencies; keep retro aesthetic + modern usability; keep anchor links stable  
+**Scale/Scope**: Small UI/formatting/linking changes in `ExperienceSection` and (if needed) `ProjectsSection`
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Personality-First Storytelling**: Improves claim→evidence linkage and readability (supports principle).
+- **II. Retro Aesthetic, Modern Usability**: Improves legibility and formatting without changing the retro style.
+- **III. Content Is a Product Surface**: Directly supports enriching content and presenting it properly.
+- **IV. Lightweight, Fast, and Durable**: No new deps; only minor string normalization and styling.
+- **V. One Source of Truth, Kept in Sync**: No dependency/scripts/deploy changes expected → docs sync not required.
+
+**Quality gates**:
+
+- `pnpm lint`
+- `pnpm build`
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/013-exp-projects-brushup/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── README.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── content/
+│   └── portfolio.ts                       # content model (ExperienceHighlight, Project.anchorId)
+└── components/
+    └── sections/
+        ├── ExperienceSection.tsx          # year badge, newline rendering, evidence link building
+        └── ProjectsSection.tsx            # evidence targets via project.anchorId
+```
+
+**Structure Decision**: Single Next.js App Router project. Implement fixes at the display layer:
+`ExperienceSection.tsx` for year size + newline rendering + evidence normalization; keep `ProjectsSection.tsx`
+as the target container with stable `id={project.anchorId}`.
+
+## Phase 0 — Outline & Research
+
+**Goal**: Decide the most robust (but minimal) Evidence parsing + matching strategy and the safest newline rendering.
+
+Research topics:
+
+- Tailwind/React best practices for preserving line breaks (`whitespace-pre-line`, etc.) without introducing XSS risk
+- Evidence parsing patterns that tolerate whitespace/newline variations and optionally accept `#anchor` style references
+
+**Output**: `specs/013-exp-projects-brushup/research.md`
+
+## Phase 1 — Design & Contracts
+
+**Data model**: Capture the relationship between Experience Highlight text, Evidence Reference, and Project targets.
+
+**Contract**: Define the supported Evidence formats (e.g., current “ / Evidence: {project title}” and optional “#anchorId”).
+
+**Quickstart**: Steps to validate the three known issues are fixed and content can be safely enriched.
+
+**Output**:
+
+- `specs/013-exp-projects-brushup/data-model.md`
+- `specs/013-exp-projects-brushup/contracts/README.md`
+- `specs/013-exp-projects-brushup/quickstart.md`
+
+## Phase 1 — Agent Context Update
+
+Run:
+
+- `.specify/scripts/bash/update-agent-context.sh cursor-agent`
+
+## Re-check Constitution (post-design)
+
+Confirm:
+
+- Evidence links work and remain stable
+- Readability improved without harming retro aesthetic
+- No new deps; `pnpm lint` + `pnpm build` pass
+
+## Phase 2 — Task Planning (handoff to /speckit.tasks)
+
+Implementation tasks will focus on:
+
+- Adjusting year badge typography in `src/components/sections/ExperienceSection.tsx`
+- Rendering Experience text with preserved line breaks
+- Normalizing Evidence references to map reliably to `project.anchorId` targets

--- a/specs/013-exp-projects-brushup/quickstart.md
+++ b/specs/013-exp-projects-brushup/quickstart.md
@@ -1,0 +1,36 @@
+# Quickstart: Validate Experience + Projects brush-up
+
+## Goal
+
+Confirm the three known issues are fixed while you enrich Experience and Projects content:
+
+1. Experience year label is readable (not “too small”).
+2. Spreadsheet line breaks render as line breaks on the web page.
+3. Evidence links in Experience jump to the correct Project.
+
+## Steps (local)
+
+1. Start dev server:
+   - `pnpm dev`
+
+2. Update Experience spreadsheet content:
+   - Add line breaks to at least one Experience `text` cell.
+   - Add an Evidence reference (e.g., ` / Evidence: <Project title>`).
+
+3. Reload the site and validate:
+   - Year badge is legible.
+   - Line breaks are preserved.
+   - Evidence is clickable and jumps to the correct Project entry.
+
+## Negative case
+
+1. Add an Evidence reference that does not match any Project.
+2. Confirm Evidence renders as plain text (not a broken link).
+
+## Production-like sanity check
+
+1. Run:
+   - `pnpm build`
+   - `pnpm start`
+2. Confirm the page renders and anchors still work.
+

--- a/specs/013-exp-projects-brushup/research.md
+++ b/specs/013-exp-projects-brushup/research.md
@@ -1,0 +1,48 @@
+# Research: Experience & Projects Content Brush-up
+
+**Feature**: `specs/013-exp-projects-brushup/spec.md`  
+**Date**: 2025-12-26
+
+## Decision 1 — Preserve spreadsheet line breaks safely
+
+**Decision**: Render Experience text using CSS whitespace preservation (e.g., `white-space: pre-line`) rather than injecting HTML.
+
+**Rationale**:
+
+- Spreadsheet text may include `\n`/`\r\n`, which normal HTML flow collapses.
+- Using CSS for whitespace is safe and preserves semantics (no HTML parsing, no XSS surface increase).
+
+**Alternatives considered**:
+
+- Injecting `<br>` via `dangerouslySetInnerHTML`: rejected due to XSS risk and unnecessary complexity.
+
+## Decision 2 — Evidence link matching strategy
+
+**Decision**: Keep the existing “Evidence” hint embedded in Experience text, but make matching tolerant of formatting differences by normalizing whitespace.
+
+**Normalization rules** (proposed):
+
+- Trim leading/trailing whitespace.
+- Collapse runs of whitespace (spaces, tabs, newlines) into a single space.
+
+**Optional supported format**:
+
+- If Evidence starts with `#`, treat it as a direct anchor reference to `project.anchorId` (e.g., `#project-go-migration`).
+
+**Rationale**:
+
+- Current implementation requires exact string match (`evidence === project.title`) and breaks on minor differences.
+- A simple normalization is lightweight and predictable.
+
+**Alternatives considered**:
+
+- Adding a new structured field to Experience highlights (e.g., `evidenceAnchorId`): possible later, but out of scope unless needed.
+
+## Decision 3 — Year label legibility
+
+**Decision**: Increase the year badge text size in Experience to improve legibility while keeping the NES badge style.
+
+**Rationale**:
+
+- The current year badge is intentionally compact, but user feedback indicates it’s too small.
+- This is a pure presentation tweak; it improves UX without affecting content.

--- a/specs/013-exp-projects-brushup/spec.md
+++ b/specs/013-exp-projects-brushup/spec.md
@@ -1,0 +1,99 @@
+# Feature Specification: Experience & Projects Content Brush-up
+
+**Feature Branch**: `013-exp-projects-brushup`  
+**Created**: 2025-12-26  
+**Status**: Draft  
+**Input**: User description: "013でExperienceとProjectsのContentsを充実させるためのブラッシュアップ。既知課題: (1) Experienceのyear表示が小さい (2) spreadsheet上の改行がWebで改行されない (3) Evidenceとの紐付けができていない。"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Experience timeline is readable and matches spreadsheet formatting (Priority: P1)
+
+As the site owner, when I maintain Experience content in a spreadsheet (including multi-line text),
+I want the website’s Experience section to render it readably (year label is legible; line breaks are preserved)
+so that the timeline communicates clearly.
+
+**Why this priority**: Experience is a primary narrative surface; readability directly affects comprehension.
+
+**Independent Test**: Update an Experience entry in the spreadsheet to include line breaks, load the page,
+and confirm the Experience entry shows those line breaks and the year label is comfortably readable.
+
+**Acceptance Scenarios**:
+
+1. **Given** an Experience entry contains line breaks in the spreadsheet, **When** the site renders the Experience section, **Then** the line breaks are displayed (not collapsed into a single line).
+2. **Given** the Experience section is rendered on desktop and mobile, **When** I scan the timeline, **Then** the year label is clearly legible and not visually “too small.”
+
+---
+
+### User Story 2 - Evidence links from Experience reliably jump to the correct Project (Priority: P2)
+
+As a reader, when an Experience item references an “Evidence” project, I want to click it and jump to
+the corresponding Project entry so I can validate the claim with concrete details.
+
+**Why this priority**: This directly supports “Personality-First Storytelling” (claim → proof).
+
+**Independent Test**: Ensure at least one Experience item includes Evidence, click it, and confirm the page scrolls to the correct Project card.
+
+**Acceptance Scenarios**:
+
+1. **Given** an Experience item includes an Evidence reference, **When** I click the Evidence link, **Then** the page navigates to the matching Project entry.
+2. **Given** minor formatting differences (extra spaces / line breaks) between spreadsheet Evidence text and Project title, **When** the Experience section renders, **Then** the Evidence link still resolves to the correct Project.
+
+---
+
+### User Story 3 - Experience & Projects content can be enriched without breaking layout (Priority: P3)
+
+As the site owner, I want to expand Experience and Projects content (longer text, more details) while keeping
+the layout readable and consistent with the retro-but-modern UX.
+
+**Why this priority**: This is the broader “content brush-up” goal beyond the three known rendering/linking issues.
+
+**Independent Test**: Add richer content to a few items and confirm the page remains readable (no overflow, no broken layout).
+
+**Acceptance Scenarios**:
+
+1. **Given** longer Experience/Project text, **When** the page renders, **Then** text wraps properly and the layout remains readable on mobile and desktop.
+
+---
+
+### Edge Cases
+
+- **Evidence mismatch**: Evidence text does not match any Project (should render as plain text, not a broken link).
+- **Evidence by anchor id**: Evidence is provided as a direct anchor reference (e.g., `#project-...`), if supported by implementation.
+- **Mixed newline types**: Spreadsheet may contain `\r\n` or `\n` line breaks (should render consistently).
+- **Very long entries**: Ensure long text doesn’t overflow or degrade readability.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The Experience section MUST render multi-line spreadsheet text with line breaks preserved.
+- **FR-002**: The Experience section MUST display the year label in a legible size on mobile and desktop.
+- **FR-003**: When an Experience item includes an Evidence reference, the system MUST link it to the matching Project entry when possible.
+- **FR-004**: Evidence matching MUST be resilient to trivial formatting differences (leading/trailing whitespace, multiple spaces, line breaks).
+- **FR-005**: If Evidence cannot be resolved to a Project, the system MUST render Evidence as non-clickable text (no broken links).
+- **FR-006**: Changes MUST NOT add new runtime dependencies and MUST keep the site deployable on Vercel.
+
+### Key Entities *(include if feature involves data)*
+
+- **Experience Highlight**: `{ year, text }` rendered in Experience; may include an Evidence hint.
+- **Project**: `{ title, anchorId, ... }` rendered in Projects; can be a target of Evidence linking.
+- **Evidence Reference**: A string embedded in Experience text that should resolve to a Project (by title or anchor id).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: An Experience entry containing multiple lines in the spreadsheet renders with the same line breaks on the web page.
+- **SC-002**: At least one Evidence link in Experience successfully navigates to the correct Project entry.
+- **SC-003**: On mobile and desktop, the Experience year label is readable without zooming.
+
+## Assumptions
+
+- Experience and Projects are sourced from the portfolio content model (public + optional private spreadsheet patch).
+- The Experience “Evidence” hint continues to be embedded in the Experience text (not a separate structured field), unless later tasks introduce a safe, backward-compatible enhancement.
+
+## Out of Scope
+
+- Adding new third-party dependencies or a CMS.
+- Large information architecture changes beyond Experience/Projects display and linking.

--- a/specs/013-exp-projects-brushup/tasks.md
+++ b/specs/013-exp-projects-brushup/tasks.md
@@ -1,0 +1,125 @@
+# Tasks: Experience & Projects Content Brush-up
+
+**Input**: Design documents from `specs/013-exp-projects-brushup/`  
+**Prerequisites**: `plan.md` (required), `spec.md` (required), `research.md`, `data-model.md`, `contracts/`, `quickstart.md`
+
+**Tests**: Not requested in the feature spec. Validation will rely on `pnpm lint`, `pnpm build`, and the manual verification steps in `specs/013-exp-projects-brushup/quickstart.md`.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm current behavior and locate the exact change points.
+
+- [x] T001 Confirm current Experience year badge styling and Evidence parsing in `src/components/sections/ExperienceSection.tsx`
+- [x] T002 [P] Confirm Projects anchors exist (`id={project.anchorId}`) in `src/components/sections/ProjectsSection.tsx`
+- [x] T003 [P] Confirm an existing whitespace-preserving pattern (`whitespace-pre-line`) in `src/components/sections/ContactSection.tsx` to reuse for Experience rendering
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Introduce small, reusable helpers for Evidence parsing + normalization (no new deps).
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [x] T004 Add a whitespace normalization helper for Evidence/title matching in `src/components/sections/ExperienceSection.tsx`
+- [x] T005 Add Evidence resolution rules (match by normalized title; optional `#anchorId` support) in `src/components/sections/ExperienceSection.tsx`
+- [x] T006 Ensure unresolved Evidence renders as plain text (non-clickable) in `src/components/sections/ExperienceSection.tsx`
+
+**Checkpoint**: Evidence parsing/matching rules are in place and ready to be used by the UI
+
+---
+
+## Phase 3: User Story 1 — Experience timeline is readable and matches spreadsheet formatting (Priority: P1) 🎯 MVP
+
+**Goal**: Year label is readable; Experience text preserves spreadsheet line breaks.
+
+**Independent Test**: Follow `specs/013-exp-projects-brushup/quickstart.md` steps for year legibility + line-break preservation.
+
+### Implementation for User Story 1
+
+- [x] T007 [US1] Increase Experience year badge font size (keep NES badge style) in `src/components/sections/ExperienceSection.tsx`
+- [x] T008 [US1] Render Experience main text with preserved line breaks (e.g., `whitespace-pre-line`) in `src/components/sections/ExperienceSection.tsx`
+- [x] T009 [US1] Validate US1 using `specs/013-exp-projects-brushup/quickstart.md` (line breaks + year legibility)
+
+**Checkpoint**: Experience renders multi-line text correctly and year is legible on mobile/desktop
+
+---
+
+## Phase 4: User Story 2 — Evidence links from Experience reliably jump to the correct Project (Priority: P2)
+
+**Goal**: Evidence references consistently link to the correct Project entry, even with whitespace/newline differences.
+
+**Independent Test**: In local dev, click an Evidence link and confirm it scrolls to the correct Project card; verify mismatch renders plain text.
+
+### Implementation for User Story 2
+
+- [x] T010 [US2] Use normalized matching to map Evidence text to `Project.anchorId` in `src/components/sections/ExperienceSection.tsx`
+- [x] T011 [US2] (Optional) Support Evidence in `#anchorId` form as a direct link to a Project anchor in `src/components/sections/ExperienceSection.tsx`
+- [x] T012 [US2] Validate US2 using `specs/013-exp-projects-brushup/quickstart.md` (match + mismatch cases)
+
+**Checkpoint**: Evidence links resolve reliably; unresolved Evidence is not clickable
+
+---
+
+## Phase 5: User Story 3 — Experience & Projects content can be enriched without breaking layout (Priority: P3)
+
+**Goal**: Longer content remains readable and doesn’t break layout.
+
+**Independent Test**: Enrich a few Experience/Project entries (longer text) and confirm layout remains readable on mobile and desktop.
+
+### Implementation for User Story 3
+
+- [x] T013 [US3] Review Experience/Projects long-text rendering and adjust typography/wrapping as needed (no layout break) in `src/components/sections/ExperienceSection.tsx` and `src/components/sections/ProjectsSection.tsx`
+- [x] T014 [US3] Validate US3 using `specs/013-exp-projects-brushup/quickstart.md` (longer entries)
+
+**Checkpoint**: Content can be enriched without degrading readability or breaking layout
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Ensure quality gates pass and docs remain accurate.
+
+- [x] T015 Run `pnpm lint` and fix any issues in `src/components/sections/ExperienceSection.tsx` / `src/components/sections/ProjectsSection.tsx`
+- [x] T016 Run `pnpm build` and fix any issues caused by the changes
+- [x] T017 Ensure `specs/013-exp-projects-brushup/contracts/README.md` matches implemented Evidence behavior (title normalization and optional `#anchorId`)
+- [x] T018 Run through `specs/013-exp-projects-brushup/quickstart.md` end-to-end and confirm it matches observed behavior
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion — BLOCKS all user stories
+- **User Stories (Phase 3–5)**: Depend on Foundational completion
+- **Polish (Phase 6)**: Depends on completing the desired user stories (at minimum US1)
+
+### User Story Dependencies
+
+- **US1 (P1)**: Depends on Phase 2 (helpers), no dependency on other stories
+- **US2 (P2)**: Depends on Phase 2 (helpers), builds on Evidence behavior and validation
+- **US3 (P3)**: Can start after US1/US2 changes land, focuses on content growth + layout stability
+
+### Parallel Opportunities
+
+- All Setup tasks marked **[P]** can run in parallel
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational
+3. Complete Phase 3: US1
+4. Validate using `specs/013-exp-projects-brushup/quickstart.md`
+
+### Incremental Delivery
+
+1. Add US1 → validate readability + line breaks
+2. Add US2 → validate Evidence linking + mismatch handling
+3. Add US3 → validate content enrichment without layout break
+

--- a/src/components/sections/ProjectsSection.tsx
+++ b/src/components/sections/ProjectsSection.tsx
@@ -19,7 +19,8 @@ export async function ProjectsSection() {
       </header>
 
       <p className="mt-3 text-sm [font-family:var(--font-noto)]">
-        具体的な事例（証拠）をまとめています。課題→対応→結果/学びを短く読める形にしています。
+        具体的な事例をまとめています。公開が難しい情報は伏せております。
+        詳細は面談などで話せる範囲で共有できます。
       </p>
 
       <div className="mt-4 grid gap-4 md:grid-cols-2">
@@ -52,7 +53,7 @@ export async function ProjectsSection() {
             <p className="mt-3 text-xs text-fami-gold [font-family:var(--font-noto)]">
               Problem / Approach
             </p>
-            <p className="mt-2 text-sm leading-relaxed [font-family:var(--font-noto)]">
+            <p className="mt-2 break-words text-sm leading-relaxed [font-family:var(--font-noto)]">
               {project.visibility === "private"
                 ? "NDA等に配慮し、公開できる範囲のみ記載しています。詳細は面談で共有できます。"
                 : project.summary}
@@ -79,7 +80,7 @@ export async function ProjectsSection() {
               <dl className="mt-3 space-y-3 text-xs [font-family:var(--font-noto)]">
                 <div className="flex gap-2">
                   <dt className="w-20 text-fami-gold">Role</dt>
-                  <dd className="font-medium">{project.role}</dd>
+                  <dd className="break-words font-medium">{project.role}</dd>
                 </div>
                 <div className="flex gap-2">
                   <dt className="w-20 text-fami-gold">Tech</dt>
@@ -93,7 +94,7 @@ export async function ProjectsSection() {
                 </div>
                 <div className="flex gap-2">
                   <dt className="w-20 text-fami-gold">Result</dt>
-                  <dd className="leading-relaxed">{project.outcomeOrLearning}</dd>
+                  <dd className="break-words leading-relaxed">{project.outcomeOrLearning}</dd>
                 </div>
               </dl>
             )}


### PR DESCRIPTION
## What
- Improve Experience readability (year badge size) and preserve spreadsheet line breaks.
- Make Experience Evidence linking robust by normalizing whitespace and supporting optional `#anchorId` form.
- Ensure long Experience/Projects text wraps without breaking layout.

## Changes
- `src/components/sections/ExperienceSection.tsx`
  - year badge font size up
  - `whitespace-pre-line` for main text
  - Evidence normalization + `#anchorId` support
- `src/components/sections/ProjectsSection.tsx`
  - add `break-words` to key text fields
- `specs/013-exp-projects-brushup/*`
  - spec/plan/tasks artifacts

## Verification
- `pnpm lint`
- `pnpm build`
- Manual: `specs/013-exp-projects-brushup/quickstart.md`
