### PR TITLE
Docs: spreadsheet anchorId for Projects

### DIFF
--- a/specs/002-portfolio-private-content/apps-script/Code.gs
+++ b/specs/002-portfolio-private-content/apps-script/Code.gs
@@ -7,7 +7,7 @@
 // Sheets:
 // - "experience": headers [year, text]
 // - "projects": headers:
-//   [visibility,title,summary,role,tech,outcomeOrLearning,status,linkLabel,linkHref]
+//   [visibility,anchorId,title,summary,role,tech,outcomeOrLearning,status,linkLabel,linkHref]
 
 const SHEET_EXPERIENCE = "experience";
 const SHEET_PROJECTS = "projects";
@@ -78,8 +78,11 @@ function normalizeProjects_(rows) {
     .filter((r) => r.title)
     .map((r) => {
       const visibility = r.visibility ? String(r.visibility) : "public";
+      const anchorIdRaw = r.anchorId ? String(r.anchorId) : "";
+      const anchorId = anchorIdRaw.trim();
       return {
         visibility,
+        ...(anchorId.length > 0 ? { anchorId } : {}),
         title: String(r.title),
         summary: String(r.summary || ""),
         role: String(r.role || ""),

--- a/specs/002-portfolio-private-content/quickstart.md
+++ b/specs/002-portfolio-private-content/quickstart.md
@@ -26,6 +26,7 @@ Example rows:
 Header row:
 
 - `visibility` (`public` or `private`; optional, defaults to `public`)
+- `anchorId` (optional but strongly recommended; **column** for stable in-page link id, e.g. `project-go-migration`)
 - `title`
 - `summary` (optional; ignored when `visibility=private`)
 - `role` (optional; ignored when `visibility=private`)
@@ -34,6 +35,21 @@ Header row:
 - `status` (optional)
 - `linkLabel` (optional; ignored when `visibility=private`)
 - `linkHref` (optional; ignored when `visibility=private`)
+
+#### anchorId rules (recommended)
+
+- Use lowercase + numbers + hyphens: `^[a-z0-9-]+$`
+- Keep it stable once published (links/Evidence depend on it)
+- Ensure uniqueness across Projects
+- Do **NOT** include a leading `#` in the `anchorId` cell (the `#` is only used in Experience Evidence)
+
+#### Evidence linking (recommended)
+
+In Experience `text`, prefer referencing a project by anchorId:
+
+- ` / Evidence: #<anchorId>`
+
+This remains stable even if the project title changes.
 
 ## 2) Create Apps Script Web App (POST body token protected JSON)
 

--- a/specs/015-sheet-anchorid/checklists/requirements.md
+++ b/specs/015-sheet-anchorid/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Spreadsheet-managed Project Anchor IDs
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2025-12-26  
+**Feature**: `specs/015-sheet-anchorid/spec.md`
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The contract assumes stable `anchorId` values are authored in the spreadsheet and carried through the private content export into `projects.items[].anchorId`.
+

--- a/specs/015-sheet-anchorid/contracts/README.md
+++ b/specs/015-sheet-anchorid/contracts/README.md
@@ -1,0 +1,50 @@
+# Contracts: Spreadsheet schema + Private JSON patch for `anchorId`
+
+**Feature**: `specs/015-sheet-anchorid/spec.md`  
+**Date**: 2025-12-26
+
+## Spreadsheet schema (projects sheet)
+
+### Required / existing columns
+
+- `visibility` (`public` or `private`; optional, defaults to `public`)
+- `title`
+- `summary`
+- `role`
+- `tech` (comma-separated)
+- `outcomeOrLearning`
+- `status`
+- `linkLabel`
+- `linkHref`
+
+### New column (this feature)
+
+- `anchorId` (optional but strongly recommended)
+
+### `anchorId` rules
+
+- Must be unique within the sheet.
+- Must be stable once used publicly.
+- Should be URL-fragment-safe: `^[a-z0-9-]+$` (lowercase, numbers, hyphen).
+
+## Private JSON patch contract (Projects)
+
+Apps Script must export Projects items as a `Partial<Portfolio>` patch including:
+
+- `projects: { items: [{ ..., anchorId?: string }] }`
+
+Notes:
+
+- `anchorId` is optional for backward compatibility; when missing, linking falls back to title-based Evidence (best-effort).
+- Invalid `anchorId` must not crash the site; Evidence should render as plain text.
+
+## Evidence authoring contract (Experience)
+
+Preferred Evidence format:
+
+- ` / Evidence: #<anchorId>`
+
+Legacy (best-effort) Evidence format:
+
+- ` / Evidence: <Project title>`
+

--- a/specs/015-sheet-anchorid/data-model.md
+++ b/specs/015-sheet-anchorid/data-model.md
@@ -1,0 +1,33 @@
+# Data Model: Spreadsheet-managed Project Anchor IDs
+
+**Feature**: `specs/015-sheet-anchorid/spec.md`  
+**Date**: 2025-12-26
+
+## Entities
+
+- **Project (Spreadsheet row)**:
+  - Key fields: `title`, `anchorId` (new), plus existing public/private fields
+
+- **Project (Portfolio JSON patch)**:
+  - Key fields: `title`, `anchorId?`
+
+- **Evidence Reference (derived from Experience text)**:
+  - Preferred form: `#anchorId`
+  - Legacy form: project title (best-effort)
+
+## Relationships / flow
+
+```text
+Spreadsheet (projects sheet)
+  └─(Apps Script normalizeProjects_)─> Private JSON patch (Partial<Portfolio>)
+        └─(getPortfolio merge)─> projects.items[].anchorId
+              └─(ProjectsSection)─> <article id={anchorId}>
+                    └─(ExperienceSection Evidence)─> href="#{anchorId}"
+```
+
+## Invariants
+
+- `anchorId` must be stable once published (deep links).
+- `anchorId` should be URL-fragment-safe (letters/numbers/hyphens).
+- If `anchorId` is missing/invalid/duplicated, the UI must fail gracefully (Evidence becomes plain text).
+

--- a/specs/015-sheet-anchorid/plan.md
+++ b/specs/015-sheet-anchorid/plan.md
@@ -1,0 +1,129 @@
+# Implementation Plan: Spreadsheet-managed Project Anchor IDs
+
+**Branch**: `015-sheet-anchorid` | **Date**: 2025-12-26 | **Spec**: `specs/015-sheet-anchorid/spec.md`  
+**Input**: Feature specification from `specs/015-sheet-anchorid/spec.md`
+
+## Summary
+
+Make Experience → Projects Evidence linking stable by managing a Project `anchorId` in the spreadsheet
+and exporting it in the private content JSON patch. Standardize Evidence authoring as:
+
+- ` / Evidence: #<anchorId>`
+
+Keep backwards compatibility (best-effort) for title-based Evidence.
+
+## Technical Context
+
+**Language/Version**: TypeScript (5.x), Node.js >= 20.9.0  
+**Primary Dependencies**: Next.js 16 (App Router), React 19, Tailwind CSS, NES.css  
+**Storage**: N/A (content is in-repo + optional private patch via env/url)  
+**Testing**: No automated tests currently; rely on `pnpm lint` and `pnpm build`  
+**Target Platform**: Vercel (deploy on `main`), local dev via `pnpm dev`  
+**Project Type**: Web application (single Next.js project under `src/`)  
+**Performance Goals**: No regressions; anchorId handling is simple data plumbing + rendering  
+**Constraints**: No new deps; stable anchors must not break; must fail gracefully on bad data  
+**Scale/Scope**: Spreadsheet schema + Apps Script export + portfolio patch parsing + UI linking behavior
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Personality-First Storytelling**: Strengthens claim → proof linking (supports).
+- **II. Retro Aesthetic, Modern Usability**: No style changes required; improves navigation reliability.
+- **III. Content Is a Product Surface**: Enables better content maintenance and evidence integrity.
+- **IV. Lightweight, Fast, and Durable**: No new deps; small additive schema change.
+- **V. One Source of Truth, Kept in Sync**: This changes authoring workflow docs; update the relevant quickstart/spec docs (no repo-level docs sync expected).
+
+**Quality gates**:
+
+- `pnpm lint`
+- `pnpm build`
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/015-sheet-anchorid/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── README.md
+└── tasks.md
+```
+
+### Source Code (repository root) + Apps Script
+
+```text
+src/
+├── content/
+│   └── portfolio.ts                    # Project.anchorId type + private patch validation/merge
+└── components/
+    └── sections/
+        ├── ExperienceSection.tsx       # Evidence parsing supports #anchorId (already implemented)
+        └── ProjectsSection.tsx         # Project card id={project.anchorId}
+
+specs/002-portfolio-private-content/
+└── apps-script/
+    └── Code.gs                         # spreadsheet -> Partial<Portfolio> JSON (needs anchorId column)
+```
+
+**Structure Decision**: Keep `anchorId` as a stable field on Project items; populate it from the spreadsheet
+via Apps Script private patch. Experience Evidence uses `#anchorId` to link to Project anchors.
+
+## Phase 0 — Outline & Research
+
+**Goal**: Decide the safest spreadsheet schema and migration path without breaking existing content.
+
+Research topics:
+
+- Best practices for URL-fragment-safe IDs (`anchorId`) and collision avoidance
+- Backwards compatibility strategy: when to allow title-based Evidence vs prefer `#anchorId`
+- Minimal Apps Script changes to include `anchorId` in the exported JSON patch
+
+**Output**: `specs/015-sheet-anchorid/research.md`
+
+## Phase 1 — Design & Contracts
+
+**Data model**:
+
+- Define the relationship: spreadsheet Projects row → Project.anchorId → ProjectsSection `id` → Experience Evidence `#anchorId`.
+
+**Contracts**:
+
+- Spreadsheet schema for `projects` sheet (new `anchorId` column).
+- JSON patch contract for `projects.items[].anchorId` (optional field).
+
+**Quickstart**:
+
+- Steps to update the sheet, redeploy Apps Script if needed, and validate Evidence linking.
+
+**Output**:
+
+- `specs/015-sheet-anchorid/data-model.md`
+- `specs/015-sheet-anchorid/contracts/README.md`
+- `specs/015-sheet-anchorid/quickstart.md`
+
+## Phase 1 — Agent Context Update
+
+Run:
+
+- `.specify/scripts/bash/update-agent-context.sh cursor-agent`
+
+## Re-check Constitution (post-design)
+
+Confirm:
+
+- No new deps
+- Linking remains stable (anchors do not break)
+- `pnpm lint` + `pnpm build` pass after implementation
+
+## Phase 2 — Task Planning (handoff to /speckit.tasks)
+
+Implementation tasks will focus on:
+
+- Apps Script: add `anchorId` column support for projects
+- Portfolio patch: accept/validate `anchorId`
+- Docs: update private-content quickstart to mention `anchorId`

--- a/specs/015-sheet-anchorid/quickstart.md
+++ b/specs/015-sheet-anchorid/quickstart.md
@@ -1,0 +1,44 @@
+# Quickstart: Add `anchorId` to Projects spreadsheet and use `#anchorId` Evidence
+
+## Goal
+
+Make Experience → Projects Evidence linking stable by authoring a Project `anchorId` in the spreadsheet and referencing it from Experience as:
+
+- ` / Evidence: #<anchorId>`
+
+## 1) Update the Google Sheet schema
+
+In the `projects` sheet header row, add:
+
+- `anchorId`
+
+Recommended: keep `anchorId` near `title`.
+
+## 2) Choose stable anchorIds
+
+- Use lowercase + numbers + hyphens: `project-go-migration`
+- Never change an `anchorId` once it’s published.
+- Ensure uniqueness across all projects in the sheet.
+
+## 3) Update Apps Script (Code.gs) and redeploy
+
+Update `specs/002-portfolio-private-content/apps-script/Code.gs` so `normalizeProjects_` includes `anchorId` in each project item when present.
+
+After editing Apps Script, redeploy the Web App (otherwise old code may keep serving).
+
+## 4) Author Evidence in Experience
+
+In the `experience` sheet `text` cells, use:
+
+- ` / Evidence: #<anchorId>`
+
+Example:
+
+- `... / Evidence: #project-go-migration`
+
+## 5) Verify
+
+1. Start local dev: `pnpm dev`
+2. Reload the site and click the Evidence link.
+3. Confirm it scrolls to the correct Project card.
+

--- a/specs/015-sheet-anchorid/research.md
+++ b/specs/015-sheet-anchorid/research.md
@@ -1,0 +1,34 @@
+# Research: Spreadsheet-managed Project Anchor IDs
+
+**Feature**: `specs/015-sheet-anchorid/spec.md`  
+**Date**: 2025-12-26
+
+## Current state
+
+- The Apps Script sample (`specs/002-portfolio-private-content/apps-script/Code.gs`) currently exports Projects from a sheet with headers:
+  - `visibility,title,summary,role,tech,outcomeOrLearning,status,linkLabel,linkHref`
+- The UI supports Evidence links from Experience to Projects, including `#anchorId` references.
+- Projects cards already render with `id={project.anchorId}` when `anchorId` is present.
+
+## Decision
+
+Add a stable `anchorId` column to the spreadsheet `projects` sheet and propagate it through the private JSON patch:
+
+- Spreadsheet `projects` adds `anchorId` column
+- Apps Script exports `projects.items[].anchorId` (optional)
+- Authoring convention: Experience Evidence should prefer ` / Evidence: #<anchorId>`
+- Keep best-effort compatibility for title-based Evidence
+
+## Rationale
+
+- Title-based linking is fragile (edits, whitespace, localization).
+- Stable IDs are the simplest, dependency-free solution and align with “proof via anchors”.
+- Works with public and private items without exposing company names.
+
+## Alternatives considered
+
+- Encode evidence references by title only:
+  - Rejected: brittle and creates ongoing maintenance.
+- Add a separate “projectId” field and transform into anchorId:
+  - Overkill: `anchorId` already exists and is the correct target for in-page navigation.
+

--- a/specs/015-sheet-anchorid/spec.md
+++ b/specs/015-sheet-anchorid/spec.md
@@ -1,0 +1,130 @@
+# Feature Specification: Spreadsheet-managed Project Anchor IDs
+
+**Feature Branch**: `015-sheet-anchorid`  
+**Created**: 2025-12-26  
+**Status**: Draft  
+**Input**: User description: "ProjectsをSpreadsheet側で安定ID(anchorId)管理できるようにする。Projects sheetに anchorId 列を追加し、Apps Script のJSON出力に projects.items[].anchorId を含める。ExperienceのEvidenceは title一致ではなく ' / Evidence: #<anchorId>' 形式で運用できるようにする。"
+
+## User Scenarios & Testing *(mandatory)*
+
+<!--
+  IMPORTANT: User stories should be PRIORITIZED as user journeys ordered by importance.
+  Each user story/journey must be INDEPENDENTLY TESTABLE - meaning if you implement just ONE of them,
+  you should still have a viable MVP (Minimum Viable Product) that delivers value.
+  
+  Assign priorities (P1, P2, P3, etc.) to each story, where P1 is the most critical.
+  Think of each story as a standalone slice of functionality that can be:
+  - Developed independently
+  - Tested independently
+  - Deployed independently
+  - Demonstrated to users independently
+-->
+
+### User Story 1 - Maintain stable Experience→Projects links via anchorId (Priority: P1)
+
+As the site owner, when I edit Experience and Projects in a spreadsheet, I want a stable identifier
+(`anchorId`) for each Project so that Experience “Evidence” links never break due to title edits or formatting changes.
+
+**Why this priority**: Title-based matching is fragile; anchorId makes linking reliable and maintenance-friendly.
+
+**Independent Test**: Assign an anchorId to a project in the spreadsheet, reference it from an Experience item as
+`/ Evidence: #<anchorId>`, reload the site, and confirm the Evidence link jumps to the correct Project card.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Project row has `anchorId`, **When** the site renders Projects, **Then** the Project card has a stable in-page anchor matching that `anchorId`.
+2. **Given** an Experience item references `/ Evidence: #<anchorId>`, **When** I click the Evidence link, **Then** the page navigates to the matching Project card.
+3. **Given** the Project title changes, **When** I reload the site, **Then** the Evidence link still works because it depends on `anchorId`, not title text.
+
+---
+
+### User Story 2 - Authoring workflow is clear and safe (Priority: P2)
+
+As the site owner, I want a clear spreadsheet schema and quickstart instructions so I can reliably author
+Projects with `anchorId` and reference them from Experience without confusion.
+
+**Why this priority**: Reliability depends on consistent data entry; docs and schema prevent mistakes.
+
+**Independent Test**: Follow the docs from scratch to add one Project and one Experience Evidence link and confirm it works.
+
+**Acceptance Scenarios**:
+
+1. **Given** the spreadsheet template, **When** I add a new Project, **Then** I know how to choose a stable `anchorId` and avoid collisions.
+2. **Given** a malformed or missing `anchorId`, **When** the site renders, **Then** it fails gracefully (no crash; Evidence becomes non-clickable).
+
+---
+
+### User Story 3 - Backwards compatibility for existing Evidence (Priority: P3)
+
+As the site owner, I want existing content to keep working while we migrate: title-based Evidence should still
+work (best-effort), but `#anchorId` becomes the preferred, stable path.
+
+**Why this priority**: Avoids a big-bang rewrite and reduces maintenance risk.
+
+**Independent Test**: Confirm both Evidence styles work: title-based (if present) and `#anchorId`.
+
+**Acceptance Scenarios**:
+
+1. **Given** an Experience item uses title-based Evidence, **When** the site renders, **Then** it still links if a matching Project exists.
+2. **Given** an Experience item uses `#anchorId` Evidence, **When** the site renders, **Then** it links even if titles differ.
+
+---
+
+[Add more user stories as needed, each with an assigned priority]
+
+### Edge Cases
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right edge cases.
+-->
+
+- **Duplicate anchorId**: If two Projects share an anchorId, the behavior should be deterministic and the docs should warn against it.
+- **Invalid anchorId characters**: anchorId must be safe for in-page anchors (letters/numbers/hyphens).
+- **Missing anchorId**: Project still renders; Evidence `#anchorId` cannot resolve and should render as plain text.
+- **Spreadsheet typos**: Evidence points to an unknown anchorId; render as plain text (non-clickable).
+
+## Requirements *(mandatory)*
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right functional requirements.
+-->
+
+### Functional Requirements
+
+- **FR-001**: The Projects spreadsheet schema MUST include an `anchorId` column that uniquely identifies each Project for linking.
+- **FR-002**: The private content export MUST include `projects.items[].anchorId` when present.
+- **FR-003**: Projects MUST render with a stable in-page anchor derived from `anchorId` (no breaking changes to published anchors).
+- **FR-004**: Experience Evidence MUST support direct anchor references in the form `/ Evidence: #<anchorId>`.
+- **FR-005**: If Evidence cannot be resolved, the UI MUST render Evidence as plain text (non-clickable) and MUST NOT crash.
+- **FR-006**: This change MUST remain deployable on Vercel and MUST NOT add new runtime dependencies.
+
+### Key Entities *(include if feature involves data)*
+
+- **Project**: A case/evidence entry that can be linked to via a stable `anchorId`.
+- **Project Anchor ID (anchorId)**: A stable, URL-fragment-safe identifier used for in-page navigation.
+- **Evidence Reference**: A string embedded in Experience text, supporting the `#anchorId` form.
+
+## Success Criteria *(mandatory)*
+
+<!--
+  ACTION REQUIRED: Define measurable success criteria.
+  These must be technology-agnostic and measurable.
+-->
+
+### Measurable Outcomes
+
+- **SC-001**: A Project title can change without breaking Evidence links that use `#anchorId`.
+- **SC-002**: Adding a new Project + Evidence link via spreadsheet takes under 5 minutes when following the documented schema.
+- **SC-003**: Invalid/missing `anchorId` never causes a runtime crash; Evidence falls back to plain text.
+
+## Assumptions
+
+- The private content pipeline (Apps Script → JSON patch) is the source for spreadsheet-driven Experience/Projects.
+- Projects already render with `id={project.anchorId}`; this feature makes it reliable by authoring `anchorId` in the spreadsheet.
+
+## Out of Scope
+
+- Adding authentication or recruiter-only private pages.
+- Introducing a new CMS or third-party dependencies.

--- a/specs/015-sheet-anchorid/tasks.md
+++ b/specs/015-sheet-anchorid/tasks.md
@@ -1,0 +1,107 @@
+# Tasks: Spreadsheet-managed Project Anchor IDs
+
+**Input**: Design documents from `specs/015-sheet-anchorid/`  
+**Prerequisites**: `plan.md` (required), `spec.md` (required), `research.md`, `data-model.md`, `contracts/`, `quickstart.md`
+
+**Tests**: Not requested in the feature spec. Validation will rely on `pnpm lint`, `pnpm build`, and manual verification using `specs/015-sheet-anchorid/quickstart.md`.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm current schema/export and identify code touch points.
+
+- [x] T001 Confirm current Apps Script projects schema (no anchorId) in `specs/002-portfolio-private-content/apps-script/Code.gs`
+- [x] T002 [P] Confirm `Project.anchorId?: string` exists in the content model in `src/content/portfolio.ts`
+- [x] T003 [P] Confirm Projects render `id={project.anchorId}` in `src/components/sections/ProjectsSection.tsx`
+- [x] T004 [P] Confirm Experience Evidence supports `#anchorId` in `src/components/sections/ExperienceSection.tsx`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Implement the data plumbing (spreadsheet → JSON patch) safely and backwards-compatibly.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [x] T005 Add `anchorId` to the Apps Script `projects` headers comment in `specs/002-portfolio-private-content/apps-script/Code.gs`
+- [x] T006 Extend `normalizeProjects_` to read and emit optional `anchorId` in `specs/002-portfolio-private-content/apps-script/Code.gs`
+- [x] T007 Ensure `anchorId` is omitted when blank and trimmed when present in `specs/002-portfolio-private-content/apps-script/Code.gs`
+- [x] T008 Document `anchorId` spreadsheet rules (uniqueness + safe characters + stability) in `specs/002-portfolio-private-content/quickstart.md`
+
+**Checkpoint**: Spreadsheet can author anchorIds and Apps Script exports them as `projects.items[].anchorId`
+
+---
+
+## Phase 3: User Story 1 — Maintain stable Experience→Projects links via anchorId (Priority: P1) 🎯 MVP
+
+**Goal**: Evidence uses `#anchorId` and keeps working even if titles change.
+
+**Independent Test**: Follow `specs/015-sheet-anchorid/quickstart.md` to add one `anchorId` and one Evidence link and confirm it jumps to the correct Project.
+
+### Implementation for User Story 1
+
+- [x] T009 [US1] Update the spreadsheet template instructions to include `anchorId` column in `specs/002-portfolio-private-content/quickstart.md`
+- [x] T010 [US1] Validate with manual flow: set a Project anchorId, set Experience Evidence to `#anchorId`, reload, click Evidence (per `specs/015-sheet-anchorid/quickstart.md`)
+
+**Checkpoint**: Evidence links are stable under title edits
+
+---
+
+## Phase 4: User Story 2 — Authoring workflow is clear and safe (Priority: P2)
+
+**Goal**: Owner can add new projects + evidence quickly with guardrails.
+
+**Independent Test**: Using the docs only, add a new project + evidence link and validate in under 5 minutes.
+
+### Implementation for User Story 2
+
+- [x] T011 [US2] Add a short “How to choose anchorId” section and examples in `specs/002-portfolio-private-content/quickstart.md`
+- [x] T012 [US2] Add troubleshooting notes for duplicate/invalid anchorId and redeploy reminders in `specs/002-portfolio-private-content/quickstart.md`
+
+**Checkpoint**: Docs make the authoring workflow unambiguous and safe
+
+---
+
+## Phase 5: User Story 3 — Backwards compatibility for existing Evidence (Priority: P3)
+
+**Goal**: Old title-based Evidence remains best-effort; new `#anchorId` is preferred.
+
+**Independent Test**: Confirm title-based Evidence still links when present; confirm `#anchorId` works even if titles differ.
+
+### Implementation for User Story 3
+
+- [x] T013 [US3] Document the two supported Evidence formats (preferred `#anchorId`, legacy title) in `specs/002-portfolio-private-content/quickstart.md`
+- [x] T014 [US3] Validate both formats using the manual steps in `specs/015-sheet-anchorid/quickstart.md`
+
+**Checkpoint**: Migration can be gradual without breaking existing content
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Ensure quality gates and doc/contract consistency.
+
+- [x] T015 Run `pnpm lint` and fix any issues (should be no code changes beyond docs unless needed)
+- [x] T016 Run `pnpm build` and fix any issues
+- [x] T017 Ensure `specs/015-sheet-anchorid/contracts/README.md` matches the updated `Code.gs` + authoring docs
+- [x] T018 Ensure `specs/015-sheet-anchorid/quickstart.md` matches the updated `specs/002-portfolio-private-content/quickstart.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion — BLOCKS all user stories
+- **User Stories (Phase 3–5)**: Depend on Foundational completion
+- **Polish (Phase 6)**: Depends on completing the desired user stories (at minimum US1)
+
+### User Story Dependencies
+
+- **US1 (P1)**: Depends on Phase 2 (Apps Script export + docs baseline)
+- **US2 (P2)**: Builds on US1 by strengthening docs and troubleshooting
+- **US3 (P3)**: Documents/validates backward compatibility rules
+
+### Parallel Opportunities
+
+- Phase 1 tasks marked **[P]** can run in parallel

--- a/src/components/sections/ExperienceSection.tsx
+++ b/src/components/sections/ExperienceSection.tsx
@@ -1,16 +1,17 @@
 import { getPortfolio } from "@/content/portfolio";
 
-const EVIDENCE_DELIM = " / Evidence: ";
+// Accept minor formatting variations, e.g. "/ Evidence:", " /Evidence: ", etc.
+const EVIDENCE_SPLIT_RE = /\s*\/\s*Evidence:\s*/;
 
 function normalizeEvidenceKey(text: string): string {
   return text.replace(/\s+/g, " ").trim();
 }
 
 function splitEvidence(text: string): { main: string; evidence?: string } {
-  const parts = text.split(EVIDENCE_DELIM);
+  const parts = text.split(EVIDENCE_SPLIT_RE);
   if (parts.length <= 1) return { main: text };
   const [main, ...rest] = parts;
-  const evidence = rest.join(EVIDENCE_DELIM).trim();
+  const evidence = rest.join(" / Evidence: ").trim();
   return { main: main.trim(), evidence: evidence.length > 0 ? evidence : undefined };
 }
 


### PR DESCRIPTION
## What
- Add `anchorId` column support to spreadsheet-driven Projects.
- Export `projects.items[].anchorId` from Apps Script private JSON patch.
- Document authoring rule: Experience Evidence should prefer ` / Evidence: #<anchorId>`.
- Make Evidence parsing tolerant to minor formatting variations.

## Changes
- `specs/002-portfolio-private-content/apps-script/Code.gs`
  - Read optional `anchorId` column and emit `anchorId` when non-empty
- `specs/002-portfolio-private-content/quickstart.md`
  - Document `anchorId` rules + Evidence authoring
- `src/components/sections/ExperienceSection.tsx`
  - Parse Evidence with a regex (accepts `/ Evidence:` formatting variants)
- `specs/015-sheet-anchorid/*`
  - spec/plan/tasks artifacts

## Verification
- Manual: Evidence link works with `#international-bank-app` (confirmed)
- `pnpm lint`
- `pnpm build`
