### PR TITLE
UI: Evidence -> Detail

### DIFF
--- a/specs/002-portfolio-private-content/quickstart.md
+++ b/specs/002-portfolio-private-content/quickstart.md
@@ -43,11 +43,11 @@ Header row:
 - Ensure uniqueness across Projects
 - Do **NOT** include a leading `#` in the `anchorId` cell (the `#` is only used in Experience Evidence)
 
-#### Evidence linking (recommended)
+#### Detail linking (recommended)
 
 In Experience `text`, prefer referencing a project by anchorId:
 
-- ` / Evidence: #<anchorId>`
+- ` / Detail: #<anchorId>`
 
 This remains stable even if the project title changes.
 

--- a/specs/015-sheet-anchorid/contracts/README.md
+++ b/specs/015-sheet-anchorid/contracts/README.md
@@ -38,13 +38,15 @@ Notes:
 - `anchorId` is optional for backward compatibility; when missing, linking falls back to title-based Evidence (best-effort).
 - Invalid `anchorId` must not crash the site; Evidence should render as plain text.
 
-## Evidence authoring contract (Experience)
+## Detail authoring contract (Experience)
 
-Preferred Evidence format:
+Preferred Detail format:
 
+- ` / Detail: #<anchorId>`
+
+Legacy (best-effort) formats:
+
+- ` / Detail: <Project title>`
 - ` / Evidence: #<anchorId>`
-
-Legacy (best-effort) Evidence format:
-
 - ` / Evidence: <Project title>`
 

--- a/specs/015-sheet-anchorid/quickstart.md
+++ b/specs/015-sheet-anchorid/quickstart.md
@@ -1,10 +1,10 @@
-# Quickstart: Add `anchorId` to Projects spreadsheet and use `#anchorId` Evidence
+# Quickstart: Add `anchorId` to Projects spreadsheet and use `#anchorId` Detail
 
 ## Goal
 
-Make Experience → Projects Evidence linking stable by authoring a Project `anchorId` in the spreadsheet and referencing it from Experience as:
+Make Experience → Projects Detail linking stable by authoring a Project `anchorId` in the spreadsheet and referencing it from Experience as:
 
-- ` / Evidence: #<anchorId>`
+- ` / Detail: #<anchorId>`
 
 ## 1) Update the Google Sheet schema
 
@@ -26,15 +26,16 @@ Update `specs/002-portfolio-private-content/apps-script/Code.gs` so `normalizePr
 
 After editing Apps Script, redeploy the Web App (otherwise old code may keep serving).
 
-## 4) Author Evidence in Experience
+## 4) Author Detail in Experience
 
 In the `experience` sheet `text` cells, use:
 
 - ` / Evidence: #<anchorId>`
+- ` / Detail: #<anchorId>`
 
 Example:
 
-- `... / Evidence: #project-go-migration`
+- `... / Detail: #project-go-migration`
 
 ## 5) Verify
 

--- a/specs/016-detail-label/spec.md
+++ b/specs/016-detail-label/spec.md
@@ -1,0 +1,115 @@
+# Feature Specification: [FEATURE NAME]
+
+**Feature Branch**: `[###-feature-name]`  
+**Created**: [DATE]  
+**Status**: Draft  
+**Input**: User description: "$ARGUMENTS"
+
+## User Scenarios & Testing *(mandatory)*
+
+<!--
+  IMPORTANT: User stories should be PRIORITIZED as user journeys ordered by importance.
+  Each user story/journey must be INDEPENDENTLY TESTABLE - meaning if you implement just ONE of them,
+  you should still have a viable MVP (Minimum Viable Product) that delivers value.
+  
+  Assign priorities (P1, P2, P3, etc.) to each story, where P1 is the most critical.
+  Think of each story as a standalone slice of functionality that can be:
+  - Developed independently
+  - Tested independently
+  - Deployed independently
+  - Demonstrated to users independently
+-->
+
+### User Story 1 - [Brief Title] (Priority: P1)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently - e.g., "Can be fully tested by [specific action] and delivers [specific value]"]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+2. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+### User Story 2 - [Brief Title] (Priority: P2)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+### User Story 3 - [Brief Title] (Priority: P3)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+[Add more user stories as needed, each with an assigned priority]
+
+### Edge Cases
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right edge cases.
+-->
+
+- What happens when [boundary condition]?
+- How does system handle [error scenario]?
+
+## Requirements *(mandatory)*
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right functional requirements.
+-->
+
+### Functional Requirements
+
+- **FR-001**: System MUST [specific capability, e.g., "allow users to create accounts"]
+- **FR-002**: System MUST [specific capability, e.g., "validate email addresses"]  
+- **FR-003**: Users MUST be able to [key interaction, e.g., "reset their password"]
+- **FR-004**: System MUST [data requirement, e.g., "persist user preferences"]
+- **FR-005**: System MUST [behavior, e.g., "log all security events"]
+
+*Example of marking unclear requirements:*
+
+- **FR-006**: System MUST authenticate users via [NEEDS CLARIFICATION: auth method not specified - email/password, SSO, OAuth?]
+- **FR-007**: System MUST retain user data for [NEEDS CLARIFICATION: retention period not specified]
+
+### Key Entities *(include if feature involves data)*
+
+- **[Entity 1]**: [What it represents, key attributes without implementation]
+- **[Entity 2]**: [What it represents, relationships to other entities]
+
+## Success Criteria *(mandatory)*
+
+<!--
+  ACTION REQUIRED: Define measurable success criteria.
+  These must be technology-agnostic and measurable.
+-->
+
+### Measurable Outcomes
+
+- **SC-001**: [Measurable metric, e.g., "Users can complete account creation in under 2 minutes"]
+- **SC-002**: [Measurable metric, e.g., "System handles 1000 concurrent users without degradation"]
+- **SC-003**: [User satisfaction metric, e.g., "90% of users successfully complete primary task on first attempt"]
+- **SC-004**: [Business metric, e.g., "Reduce support tickets related to [X] by 50%"]

--- a/src/components/sections/ExperienceSection.tsx
+++ b/src/components/sections/ExperienceSection.tsx
@@ -1,17 +1,18 @@
 import { getPortfolio } from "@/content/portfolio";
 
-// Accept minor formatting variations, e.g. "/ Evidence:", " /Evidence: ", etc.
-const EVIDENCE_SPLIT_RE = /\s*\/\s*Evidence:\s*/;
+// Prefer "Detail" in the UI, but keep backwards compatibility with existing "Evidence" authoring.
+// Accept minor formatting variations, e.g. "/ Detail:", " /Detail: ", "/ Evidence:", etc.
+const DETAIL_SPLIT_RE = /\s*\/\s*(?:Detail|Evidence):\s*/;
 
 function normalizeEvidenceKey(text: string): string {
   return text.replace(/\s+/g, " ").trim();
 }
 
 function splitEvidence(text: string): { main: string; evidence?: string } {
-  const parts = text.split(EVIDENCE_SPLIT_RE);
+  const parts = text.split(DETAIL_SPLIT_RE);
   if (parts.length <= 1) return { main: text };
   const [main, ...rest] = parts;
-  const evidence = rest.join(" / Evidence: ").trim();
+  const evidence = rest.join(" / Detail: ").trim();
   return { main: main.trim(), evidence: evidence.length > 0 ? evidence : undefined };
 }
 
@@ -62,7 +63,7 @@ export async function ExperienceSection() {
                 <p className="break-words whitespace-pre-line leading-relaxed">{main}</p>
                 {normalizedEvidence ? (
                   <p className="mt-1 text-xs text-fami-ivory/90">
-                    <span className="text-fami-gold">Evidence</span>:{" "}
+                    <span className="text-fami-gold">Detail</span>:{" "}
                     {anchor ? (
                       <a className="underline" href={`#${anchor}`}>
                         {normalizedEvidence}


### PR DESCRIPTION
## What
- Rename Experience link label from "Evidence" to "Detail".
- Keep backwards compatibility: authoring can be either `/ Detail:` or legacy `/ Evidence:`.

## Changes
- `src/components/sections/ExperienceSection.tsx`
  - parse `/ Detail:` and `/ Evidence:` with a single regex
  - UI label now shows "Detail"
- `specs/002-portfolio-private-content/quickstart.md`
  - recommend ` / Detail: #<anchorId>`
- `specs/015-sheet-anchorid/contracts/README.md` + `specs/015-sheet-anchorid/quickstart.md`
  - update examples and note legacy formats

## Verification
- `pnpm lint`
- `pnpm build`
