### PR TITLE
Activities: add Achievements group

### DIFF
--- a/specs/018-activities-achievements/contracts/README.md
+++ b/specs/018-activities-achievements/contracts/README.md
@@ -1,0 +1,68 @@
+# Contracts: 018 – Activities: Achievements (Awards)
+
+## Portfolio JSON patch (private override) contract
+
+This repo supports overriding `publicPortfolio` with a **Partial\<Portfolio\>** patch via:
+
+- `PORTFOLIO_PRIVATE_JSON`, or
+- `PORTFOLIO_PRIVATE_URL` (Apps Script / JSON endpoint)
+
+For this feature, the patch may include `activities.groups` with the new group name.
+
+### Important: `groups` replaces the whole list
+
+In this codebase, private overrides are merged shallowly:
+
+- `activities: { ...base.activities, ...patch.activities }`
+
+So if you provide `activities.groups`, it will **replace the entire groups array** (it does not deep-merge group items).
+
+**Recommendation**: If you override `activities.groups`, include *all* groups you want to show (Talks/Books/Community/Achievements) in the desired order.
+
+### Example (recommended): include all groups
+
+```json
+{
+  "activities": {
+    "heading": "Activities",
+    "groups": [
+      {
+        "name": "Talks",
+        "items": []
+      },
+      {
+        "name": "Books",
+        "items": []
+      },
+      {
+        "name": "Community",
+        "items": []
+      },
+      {
+        "name": "Achievements",
+        "items": [
+          {
+            "year": "2024",
+            "title": "Example Award",
+            "context": "Optional context",
+            "link": { "label": "Details", "href": "https://example.com" }
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### `activities.groups[].name` allowed values
+
+- `Talks`
+- `Books`
+- `Community`
+- `Achievements` (**new**)
+
+## Spreadsheet (Apps Script) contract
+
+Out of scope for this feature: the current Apps Script exporter only supports `experience` + `projects`.
+
+

--- a/specs/018-activities-achievements/data-model.md
+++ b/specs/018-activities-achievements/data-model.md
@@ -1,0 +1,35 @@
+# Data Model: 018 – Activities: Achievements (Awards)
+
+## Overview
+
+This feature extends the existing `portfolio.activities.groups` model by adding a new group name `Achievements`.
+
+No new top-level sections are introduced.
+
+## Types (conceptual)
+
+### ActivityItem
+
+- `year`: string (display label; e.g. `"2024"` or `"2019–2025"`)
+- `title`: string
+- `context?`: string (optional)
+- `link?`: `{ label: string; href: string }` (optional)
+
+### ActivityGroup
+
+- `name`: `"Talks" | "Books" | "Community" | "Achievements"`
+- `items`: `ActivityItem[]`
+
+### Portfolio.activities
+
+- `id`: `"activities"` (TOC anchor)
+- `heading`: string
+- `groups`: `ActivityGroup[]`
+
+## Validation / rendering rules
+
+- `items=[]` is allowed; UI must show an explicit empty state (“Coming soon”).
+- External links (`href` starting with `http://` or `https://`) must open in a new tab and include `rel="noreferrer"`.
+- Group ordering is determined by content order in `portfolio.activities.groups` (no sorting).
+
+

--- a/specs/018-activities-achievements/plan.md
+++ b/specs/018-activities-achievements/plan.md
@@ -1,0 +1,121 @@
+# Implementation Plan: 018 – Activities: Achievements (Awards)
+
+**Branch**: `018-activities-achievements` | **Date**: 2025-12-28 | **Spec**: `specs/018-activities-achievements/spec.md`
+**Input**: Feature specification from `specs/018-activities-achievements/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/commands/plan.md` for the execution workflow.
+
+## Summary
+
+Add an `Achievements` group under the existing `Activities` section, reusing the existing Activities item schema and UI patterns (safe external links, explicit empty state).
+
+## Technical Context
+
+<!--
+  ACTION REQUIRED: Replace the content in this section with the technical details
+  for the project. The structure here is presented in advisory capacity to guide
+  the iteration process.
+-->
+
+**Language/Version**: TypeScript 5.x (Next.js 16 App Router)  
+**Primary Dependencies**: Next.js, React 19, Tailwind CSS, NES.css  
+**Storage**: N/A (static content) + optional private override via env/url (server-side fetch)  
+**Testing**: No automated tests; quality gates are `pnpm lint` + `pnpm build`  
+**Target Platform**: Vercel  
+**Project Type**: Web application (single-page portfolio)  
+**Performance Goals**: Keep it lightweight; avoid new runtime deps  
+**Constraints**: Preserve scan-ability; keep Activities consistent; external links must be safe (`target="_blank"` + `rel="noreferrer"`)  
+**Scale/Scope**: Extend existing Activities group enum and default content; no new sections/TOC items
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Use `.specify/memory/constitution.md` as the source of truth. This repo’s default
+gates (adapt per feature) are:
+
+- Principle compliance: changes support “Personality-First Storytelling” and do not
+  dilute the retro aesthetic + usability balance.
+- Quality gates: `pnpm lint` and `pnpm build` pass.
+- Docs sync: if dependencies/scripts/runtime/deploy/top-level UX change, update
+  `README.md`, `AGENTS.md`, and `CLAUDE.md` together.
+
+**Gate Result (pre-research)**: PASS (expected; small content-model + UI copy change)
+
+## Phase 0: Outline & Research
+
+### Decisions / NEEDS CLARIFICATION
+
+- **Where should awards/achievements live?**
+  - Decision target: extend existing `Activities.groups` with a new group name `Achievements`.
+  - Rationale: minimal UI change, keeps proof surface cohesive, NDA-safe.
+- **Data shape**
+  - Keep `ActivityItem` schema unchanged (`year`, `title`, optional `context`, optional `link`).
+- **Private content integration**
+  - Current Apps Script spreadsheet exporter only supports `experience` + `projects`.
+  - Decision needed: keep achievements authored in `publicPortfolio` (or private JSON) for now vs extend spreadsheet schema.
+
+**Output**: `specs/018-activities-achievements/research.md`
+
+## Phase 1: Design & Contracts
+
+### Data model
+
+- Extend `ActivityGroup.name` union to include `Achievements`.
+- Add `Achievements` group in `publicPortfolio.activities.groups` (order defined in content).
+
+### Contracts
+
+- Portfolio patch contract for `activities.groups[].name` includes `Achievements`.
+- No external API changes (links only).
+
+### Quickstart
+
+- Add an Achievements item, verify it renders under Activities.
+- Verify empty state and external link safety.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/018-activities-achievements/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+<!--
+  ACTION REQUIRED: Replace the placeholder tree below with the concrete layout
+  for this feature. Delete unused options and expand the chosen structure with
+  real paths (e.g., apps/admin, packages/something). The delivered plan must
+  not include Option labels.
+-->
+
+```text
+src/
+├── components/
+│   └── sections/
+│       └── ActivitiesSection.tsx
+└── content/
+    └── portfolio.ts
+```
+
+**Structure Decision**: Single Next.js app; update content model in `src/content/portfolio.ts` and (if needed) copy in `src/components/sections/ActivitiesSection.tsx`.
+
+## Re-check Constitution (post-design)
+
+**Gate Result (post-design)**: PASS (expected; no new deps; small content-model extension)
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| [e.g., 4th project] | [current need] | [why 3 projects insufficient] |
+| [e.g., Repository pattern] | [specific problem] | [why direct DB access insufficient] |

--- a/specs/018-activities-achievements/quickstart.md
+++ b/specs/018-activities-achievements/quickstart.md
@@ -1,0 +1,25 @@
+# Quickstart: 018 – Activities: Achievements (Awards)
+
+## Goal
+
+Add awards/achievements under the existing Activities section, using the same list UI and item schema.
+
+## 1) Add content
+
+Edit `src/content/portfolio.ts` and add an `Achievements` group (or items within it) under `publicPortfolio.activities.groups`.
+
+## 2) Verify behavior
+
+1. Run `pnpm dev`.
+2. Open the site and scroll to `#activities`.
+3. Confirm:
+   - The group header `Achievements` is visible.
+   - Items show `year` + `title` (and optional `context`).
+   - If `link.href` is external (`http(s)`), it opens in a new tab and does not send a referrer (`rel="noreferrer"`).
+   - If the group has zero items, the UI shows “Coming soon”.
+
+## 3) Optional: private override
+
+If you want to keep achievements private, override via `PORTFOLIO_PRIVATE_JSON` / `PORTFOLIO_PRIVATE_URL` using the contract in `specs/018-activities-achievements/contracts/README.md`.
+
+

--- a/specs/018-activities-achievements/research.md
+++ b/specs/018-activities-achievements/research.md
@@ -1,0 +1,33 @@
+# Research: 018 – Activities: Achievements (Awards)
+
+## Decision 1: Where to place awards/achievements
+
+- **Decision**: Add a new `Activities` group named `Achievements`.
+- **Rationale**: Minimal UX and data-model change; keeps “proof” content grouped with talks/books/community; avoids adding a new TOC item or section.
+- **Alternatives considered**:
+  - New top-level section “Achievements” → more prominent, but increases TOC size and splits proof surfaces.
+  - Merge into `Projects` → mixes “work output” with “recognition”; less scannable.
+
+## Decision 2: Data shape
+
+- **Decision**: Reuse `ActivityItem` as-is: `{ year, title, context?, link? }`.
+- **Rationale**: Awards/achievements fit the existing item model (year + title + optional context/link). No new schema needed.
+- **Alternatives considered**:
+  - Add structured fields like `issuer`, `category`, `rank` → richer, but premature complexity for a portfolio.
+
+## Decision 3: Naming / UI label
+
+- **Decision**: Use English group label `Achievements` to match existing group names (`Talks`, `Books`, `Community`).
+- **Rationale**: Consistent visual hierarchy (uppercase group headers) and minimal code change.
+- **Alternatives considered**:
+  - `Awards` only → too narrow (achievements can include certifications / selections).
+  - Japanese group labels → could be fine, but would diverge from current group naming.
+
+## Decision 4: Private content integration
+
+- **Decision**: Keep authoring for Achievements in `publicPortfolio` (repo) or via existing private JSON patch override.
+- **Rationale**: Current Apps Script / spreadsheet exporter supports only `experience` + `projects`. Extending spreadsheet schema is a separate scope increase and can be added later if desired.
+- **Alternatives considered**:
+  - Extend Apps Script with an `activities` sheet → nice workflow parity, but requires new sheet schema + docs + migration support.
+
+

--- a/specs/018-activities-achievements/spec.md
+++ b/specs/018-activities-achievements/spec.md
@@ -1,0 +1,67 @@
+# Feature Specification: 018 – Activities: Achievements (Awards)
+
+**Feature Branch**: `018-activities-achievements`  
+**Created**: 2025-12-28  
+**Status**: Draft  
+**Input**: User description: "Activityに賞の受賞とかAchivementを入れたい。"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Achievements are visible under Activities (Priority: P1)
+
+As a reader, I want to quickly scan awards/achievements so I can understand credibility and proof beyond Projects.
+
+**Why this priority**: Adds concrete “proof” content with minimal NDA risk; aligns with Personality-First Storytelling.
+
+**Independent Test**: Add at least one Achievement item in content, reload page, and confirm it renders under Activities with year + title + optional link.
+
+**Acceptance Scenarios**:
+
+1. **Given** Activities section exists, **When** a group named `Achievements` has at least 1 item, **Then** the UI shows that group and lists the item(s).
+2. **Given** an Achievement item has an external `link`, **When** I click it, **Then** it opens in a new tab with `rel="noreferrer"`.
+
+---
+
+### User Story 2 - Empty state is explicit (Priority: P2)
+
+As the site owner, I want a clear empty state so the UI never looks broken even if Achievements is not populated yet.
+
+**Why this priority**: Prevents awkward blank sections; keeps UX consistent with existing Activities groups.
+
+**Independent Test**: Set Achievements group `items=[]` and confirm “Coming soon” is shown for that group.
+
+**Acceptance Scenarios**:
+
+1. **Given** Activities groups include `Achievements` with zero items, **When** I scroll to Activities, **Then** that group shows “Coming soon”.
+
+---
+
+### Edge Cases
+
+- Achievements item has no `context` and no `link` → still renders cleanly (year + title).
+- Many items in a group → still readable and scannable (wrapping, no layout break).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST support an `Achievements` group inside `portfolio.activities.groups`.
+- **FR-002**: System MUST render Achievements using the same item schema as other Activities groups (`year`, `title`, optional `context`, optional `link`).
+- **FR-003**: System MUST keep external links safe (`target="_blank"` + `rel="noreferrer"`).
+- **FR-004**: System MUST show an explicit empty state (“Coming soon”) when a group has no items.
+- **FR-005**: System MUST remain backward compatible with existing Activities groups (Talks/Books/Community).
+
+### Key Entities
+
+- **ActivityGroup**: `{ name, items[] }` where `name` includes `Achievements`.
+- **ActivityItem**: `{ year, title, context?, link? }`.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Achievements can be added without introducing a new section or new data shape (minimal maintenance).
+- **SC-002**: The page remains scannable; Achievements items are readable on mobile and desktop.
+- **SC-003**: `pnpm lint` and `pnpm build` pass.
+
+

--- a/specs/018-activities-achievements/tasks.md
+++ b/specs/018-activities-achievements/tasks.md
@@ -1,0 +1,95 @@
+---
+description: "Tasks for 018 – Activities: Achievements (Awards)"
+---
+
+# Tasks: 018 – Activities: Achievements (Awards)
+
+**Input**: Design documents from `/Users/takeshiwatanabe/EureWorks/private/git/portfolio/specs/018-activities-achievements/`  
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/`, `quickstart.md`  
+**Tests**: Not requested (use `pnpm lint` + `pnpm build` as quality gates)
+
+## Phase 1: Setup (Shared Infrastructure)
+
+- [ ] T001 Confirm spec/plan artifacts exist and are consistent (`specs/018-activities-achievements/spec.md`, `specs/018-activities-achievements/plan.md`)
+- [ ] T002 Review current Activities implementation and data model (`src/components/sections/ActivitiesSection.tsx`, `src/content/portfolio.ts`)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+> No separate foundational infrastructure is required for this feature (no new deps, no new routes).
+
+- [ ] T003 Confirm current build passes before changes (`pnpm lint`, `pnpm build`)
+
+**Checkpoint**: Baseline is green; start user story work.
+
+---
+
+## Phase 3: User Story 1 - Achievements are visible under Activities (Priority: P1) 🎯 MVP
+
+**Goal**: Add an `Achievements` group to `Activities` with the same item schema and safe external link behavior.
+
+**Independent Test**: Add an Achievements group with at least one item in `src/content/portfolio.ts`, reload page, and confirm it renders under `#activities` (year + title + optional link).
+
+- [ ] T004 [US1] Extend `ActivityGroup.name` union to include `Achievements` in `src/content/portfolio.ts`
+- [ ] T005 [US1] Add an `Achievements` group to `publicPortfolio.activities.groups` in `src/content/portfolio.ts` (start with `items: []` to allow safe incremental authoring)
+- [ ] T006 [US1] Ensure Activities intro copy still matches categories (optionally mention achievements) in `src/components/sections/ActivitiesSection.tsx`
+- [ ] T007 [US1] Add 1 temporary local-only Achievements item to validate rendering, then decide final source:
+  - keep it in `publicPortfolio` (if it’s truly public), or
+  - move it to private override (if it should be private)
+  (`src/content/portfolio.ts` and/or your private override source)
+- [ ] T008 [US1] Confirm override semantics note is present and correct in `specs/018-activities-achievements/contracts/README.md` (groups array is replaced, not deep-merged)
+
+**Checkpoint**: Achievements group can be rendered, and external link behavior remains safe.
+
+---
+
+## Phase 4: User Story 2 - Empty state is explicit (Priority: P2)
+
+**Goal**: Ensure the Achievements group behaves well when empty (explicit “Coming soon”).
+
+**Independent Test**: Keep `Achievements.items = []` and confirm the group shows “Coming soon” under Activities without layout issues.
+
+- [ ] T009 [US2] Verify empty state behavior for empty Achievements group in `src/components/sections/ActivitiesSection.tsx` (no code changes if already correct)
+- [ ] T010 [US2] Validate long titles/context wrapping does not break layout (mobile + desktop) and adjust classes if needed in `src/components/sections/ActivitiesSection.tsx`
+
+**Checkpoint**: Achievements group is visible and never looks broken even when empty.
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+- [ ] T011 Update docs where necessary for authoring guidance (if contract/quickstart changed): `specs/018-activities-achievements/quickstart.md`
+- [ ] T012 Run quality gates and confirm no regressions (`pnpm lint`, `pnpm build`)
+- [ ] T013 Run quickstart verification steps in `specs/018-activities-achievements/quickstart.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- Phase 1 (Setup) → Phase 2 (Baseline build) → Phase 3 (US1) → Phase 4 (US2) → Phase 5 (Polish)
+
+### User Story Dependencies
+
+- **US1 (P1)**: Depends on baseline green build (T003). No dependency on US2.
+- **US2 (P2)**: Depends on US1 having an Achievements group present in data (T005).
+
+### Parallel Opportunities
+
+- Most work is in `src/content/portfolio.ts` and `src/components/sections/ActivitiesSection.tsx`; do sequentially to avoid conflicts.
+- Docs tasks (T008, T011) can be done in parallel with UI changes if needed.
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+- Implement T004–T008, then validate the independent test for US1.
+- Keep Achievements items empty by default unless you have truly public awards to publish.
+
+### Incremental Delivery
+
+- Ship capability + empty state first (US1/US2), then add real Achievements items via public content or private override.

--- a/src/components/sections/ActivitiesSection.tsx
+++ b/src/components/sections/ActivitiesSection.tsx
@@ -17,7 +17,7 @@ export async function ActivitiesSection() {
       </h2>
 
       <p className="mt-3 text-sm [font-family:var(--font-noto)]">
-        登壇・執筆・コミュニティ活動をまとめています。
+        登壇・執筆・コミュニティ活動・受賞/実績をまとめています。
       </p>
 
       <div className="mt-5 space-y-6">

--- a/src/content/portfolio.ts
+++ b/src/content/portfolio.ts
@@ -274,7 +274,24 @@ export const publicPortfolio: Portfolio = {
       },
       {
         name: "Achievements",
-        items: [],
+        items: [
+          {
+            year: "2018/03",
+            title: "TOEIC 900点",
+          },
+          {
+            year: "2019/07",
+            title: "新卒のIT研修で同期で1番を取る",
+          },
+          {
+            year: "2020/03",
+            title: "第一回AWS ANGEL Dojo アライアンス賞受賞",
+          },
+          {
+            year: "2021/06",
+            title: "AWS Certified DevOps Engineer – Professional",
+          },
+        ],
       },
     ],
   },

--- a/src/content/portfolio.ts
+++ b/src/content/portfolio.ts
@@ -276,20 +276,17 @@ export const publicPortfolio: Portfolio = {
         name: "Achievements",
         items: [
           {
-            year: "2018/03",
-            title: "TOEIC 900点",
+            year: "2019",
+            title: "新卒のIT研修でシステム開発演習があり、同期で1番を取る。",
           },
           {
-            year: "2019/07",
-            title: "新卒のIT研修で同期で1番を取る",
+            year: "2020",
+            title: "第一回AWS ANGEL Dojo アライアンス賞受賞。",
+            link: { label: "AWS ANGEL Dojo", href: "https://aws.amazon.com/jp/blogs/psa/angel-dojo-season1/" },
           },
           {
-            year: "2020/03",
-            title: "第一回AWS ANGEL Dojo アライアンス賞受賞",
-          },
-          {
-            year: "2021/06",
-            title: "AWS Certified DevOps Engineer – Professional",
+            year: "2021",
+            title: "AWS Certified DevOps Engineer Professional 取得。",
           },
         ],
       },

--- a/src/content/portfolio.ts
+++ b/src/content/portfolio.ts
@@ -78,7 +78,7 @@ export type ActivityItem = {
 };
 
 export type ActivityGroup = {
-  name: "Talks" | "Books" | "Community";
+  name: "Talks" | "Books" | "Community" | "Achievements";
   items: ActivityItem[];
 };
 
@@ -271,6 +271,10 @@ export const publicPortfolio: Portfolio = {
             link: { label: "Cloud Native Days", href: "https://cloudnativedays.jp/" },
           },
         ],
+      },
+      {
+        name: "Achievements",
+        items: [],
       },
     ],
   },


### PR DESCRIPTION
## What
- Add `Achievements` as a new group under Activities.
- Reuse existing Activities item schema; keep empty-state behavior ("Coming soon").
- Update Activities intro copy to mention achievements.

## Notes
- `activities.groups` is replaced wholesale when provided via private override (documented in feature contract).

## Verification
- pnpm lint
- pnpm build
