### PR TITLE
Gamefeel: project visuals + subtle motion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,11 @@ Unified cheat sheet so any AI agent (Claude Code, GPT, etc.) can understand the 
   - Writing/Blog links live in `portfolio.writing` and are rendered in `src/components/sections/WritingSection.tsx`.
   - Activities (Talks/Books/Community) live in `portfolio.activities` and are rendered in `src/components/sections/ActivitiesSection.tsx`.
   - Work (company/organization blocks with nested Projects) lives in `portfolio.work` and is rendered in `src/components/sections/WorkSection.tsx`.
+  - Optional visuals:
+    - Static assets live under `public/assets/`
+    - Projects can optionally specify `project.asset` to render a diagram/thumbnail in Work
+  - Motion:
+    - CSS-only motion utilities live in `src/app/globals.css` (e.g. reduced-motion aware helpers)
 
 ## Workflow Expectations
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,8 @@ Focused tips for Anthropic Claude Code / Workbench agents interacting with this 
   - `PORTFOLIO_PRIVATE_SOURCE` = `env` (url mode is deprecated/unsupported)
   - `PORTFOLIO_PRIVATE_JSON` (JSON string)
   - Skills use `years` (required) and can optionally include `firstUsedYear` / `lastUsedYear` (numeric years) to show recency.
+- `public/assets/` – Static diagrams/screenshots (optional); Projects can specify `project.asset` to render visuals.
+- `src/app/globals.css` – Global palette + small CSS-only motion utilities (reduced-motion aware).
 - `src/app/layout.tsx` – Imports NES.css, fonts, metadata; extend when adding OG tags or global providers.
 - `tailwind.config.js` – Update `content` array if adding directories.
 - `postcss.config.js` – Standard pipeline; modify when adding plugins like `postcss-nesting`.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ When a change affects dependencies or workflows, remember to update README / doc
 ## Customizing next steps
 
 - Update the copy/data in `src/content/portfolio.ts` (profile/work/writing/activities/skills/contact).
+- Add optional visuals to Projects:
+  - Put diagrams/screenshots under `public/assets/`
+  - Set `project.asset` in `src/content/portfolio.ts` to render a thumbnail/diagram in Work
 - If you want to keep some details off the public repo, you can provide private overrides via
   environment variables (see `src/content/portfolio.ts`: `PORTFOLIO_PRIVATE_JSON`).
   - Projects can include `visibility: "public" | "private"`. Private items will be redacted

--- a/public/assets/diagrams/go-migration.svg
+++ b/public/assets/diagrams/go-migration.svg
@@ -1,0 +1,44 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="540" viewBox="0 0 960 540" role="img" aria-label="段階移行（切替/ロールバック前提）の概念図">
+  <defs>
+    <style>
+      .bg { fill: #1b1b1b; }
+      .box { fill: #212529; stroke: #d7b05b; stroke-width: 6; }
+      .txt { fill: #f8f1dc; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; font-size: 22px; }
+      .sub { fill: rgba(248,241,220,0.85); font-size: 18px; }
+      .accent { fill: #d7b05b; }
+      .arrow { stroke: #a20000; stroke-width: 10; fill: none; stroke-linecap: round; stroke-linejoin: round; }
+      .dash { stroke-dasharray: 14 10; }
+    </style>
+  </defs>
+
+  <rect class="bg" x="0" y="0" width="960" height="540" rx="18" />
+
+  <text class="txt accent" x="40" y="60">Go migration: safe cutover with rollback</text>
+  <text class="sub" x="40" y="92">段階移行 / 切替 / ロールバックを“最初から設計に入れる”</text>
+
+  <rect class="box" x="60" y="130" width="260" height="120" rx="14" />
+  <text class="txt" x="90" y="180">Legacy</text>
+  <text class="sub" x="90" y="210">既存システム</text>
+
+  <rect class="box" x="350" y="130" width="260" height="120" rx="14" />
+  <text class="txt" x="380" y="180">Gateway</text>
+  <text class="sub" x="380" y="210">ルーティング/切替</text>
+
+  <rect class="box" x="640" y="130" width="260" height="120" rx="14" />
+  <text class="txt" x="670" y="180">Go Service</text>
+  <text class="sub" x="670" y="210">新実装</text>
+
+  <path class="arrow" d="M 320 190 L 350 190" />
+  <path class="arrow" d="M 610 190 L 640 190" />
+
+  <rect class="box" x="60" y="300" width="840" height="170" rx="14" />
+  <text class="txt" x="90" y="350">Observability + Safe ops</text>
+  <text class="sub" x="90" y="382">metrics / logs / traces  +  feature flag  +  rollback switch</text>
+  <text class="sub" x="90" y="414">段階移行を“運用に載せる”ための可観測性と切替手順</text>
+
+  <path class="arrow dash" d="M 190 250 L 190 300" />
+  <path class="arrow dash" d="M 480 250 L 480 300" />
+  <path class="arrow dash" d="M 770 250 L 770 300" />
+</svg>
+
+

--- a/specs/021-gamefeel/contracts/README.md
+++ b/specs/021-gamefeel/contracts/README.md
@@ -1,0 +1,31 @@
+# Contracts: Assets + Motion (internal)
+
+**Feature**: `specs/021-gamefeel/spec.md`  
+**Date**: 2025-12-28
+
+## Purpose
+
+Define an internal authoring contract for attaching visual assets to Projects.
+No external APIs are introduced by this feature.
+
+## Project asset contract
+
+If `project.asset` is present:
+
+- `asset.src` MUST be a path under `public/` (served by Next.js), e.g. `"/assets/diagrams/foo.svg"`
+- `asset.alt` MUST be present and meaningful
+- `asset.kind` MUST be one of: `diagram | screenshot | pixel-art`
+- For raster (`kind=screenshot` typically), `asset.width` and `asset.height` SHOULD be provided if rendered via `next/image`
+
+### Asset size guidance (guardrails)
+
+- Prefer **SVG** for diagrams (small, scalable).
+- If using raster images:
+  - Prefer **WebP** and keep file size small (rule of thumb: < 200KB per image).
+  - Avoid embedding sensitive data (names, IDs, internal screenshots).
+
+## Reduced motion contract
+
+- Any animation MUST be disabled or reduced when `prefers-reduced-motion: reduce` is active.
+
+

--- a/specs/021-gamefeel/data-model.md
+++ b/specs/021-gamefeel/data-model.md
@@ -1,0 +1,43 @@
+# Data Model: Assets + Motion
+
+**Feature**: `specs/021-gamefeel/spec.md`  
+**Date**: 2025-12-28
+
+## Overview
+
+This feature enriches the existing Work → Projects proof surface with optional visual assets
+(images/diagrams) and adds subtle, accessible motion.
+
+## Entities
+
+### `Asset`
+
+Represents a visual attached to a Project (or later, to a WorkEntry).
+
+- `src`: string (path under `public/`, e.g. `"/assets/diagrams/go-migration.svg"`)
+- `alt`: string (required for accessibility)
+- `kind`: `"diagram" | "screenshot" | "pixel-art"`
+- `width?` / `height?`: number (required for raster images if using `next/image`)
+
+### `Project` (extension)
+
+- Add optional field:
+  - `asset?: Asset`
+
+### `MotionPreset` (CSS concept)
+
+Not stored as data initially; represented by CSS classes:
+
+- `pixel-float` (subtle vertical bob)
+- `blink-soft` (low-frequency blink)
+- Must be disabled under `prefers-reduced-motion: reduce`
+
+## Rendering / Validation Rules
+
+- If `project.asset` exists:
+  - UI MUST render it (diagram or thumbnail)
+  - UI MUST include `alt` text
+- If the asset path is invalid/missing, UI MUST fall back gracefully (placeholder area or hide asset region without layout break).
+- Motion MUST be subtle and MUST respect reduced motion preference.
+
+

--- a/specs/021-gamefeel/plan.md
+++ b/specs/021-gamefeel/plan.md
@@ -1,0 +1,96 @@
+# Implementation Plan: Gamefeel Upgrade (Images/Diagrams + Retro Motion)
+
+**Branch**: `021-gamefeel` | **Date**: 2025-12-28 | **Spec**: `specs/021-gamefeel/spec.md`
+**Input**: Feature specification from `specs/021-gamefeel/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/commands/plan.md` for the execution workflow.
+
+## Summary
+
+Retro雰囲気を維持しつつ、Work/Projects に画像/図（サムネ/ダイアグラム）を追加し、
+CSS中心の軽量な“ゲームっぽい動き”を導入して体験品質を上げる。
+`prefers-reduced-motion` に対応し、パフォーマンス劣化を避ける。
+
+## Technical Context
+
+<!--
+  ACTION REQUIRED: Replace the content in this section with the technical details
+  for the project. The structure here is presented in advisory capacity to guide
+  the iteration process.
+-->
+
+**Language/Version**: TypeScript 5.x (Next.js App Router)  
+**Primary Dependencies**: Next.js 16, React 19, Tailwind CSS 3, NES.css  
+**Storage**: N/A (static assets under `public/`)  
+**Testing**: N/A (no automated tests; rely on `pnpm lint` + `pnpm build`)  
+**Target Platform**: Vercel  
+**Project Type**: Web application (Next.js App Router under `src/`)  
+**Performance Goals**: Keep static-first; avoid heavy JS; images optimized; motion CSS-first  
+**Constraints**: Must respect `prefers-reduced-motion`; avoid motion sickness; keep retro aesthetic + readability  
+**Scale/Scope**: Single-page portfolio; add a small number of curated visuals (not a gallery)
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Use `.specify/memory/constitution.md` as the source of truth. This repo’s default
+gates (adapt per feature) are:
+
+- Principle compliance: changes support “Personality-First Storytelling” and do not
+  dilute the retro aesthetic + usability balance.
+- Quality gates: `pnpm lint` and `pnpm build` pass.
+- Docs sync: if dependencies/scripts/runtime/deploy/top-level UX change, update
+  `README.md`, `AGENTS.md`, and `CLAUDE.md` together.
+
+**Gate Evaluation (pre-research)**:
+- Principle I (Personality-First): Visuals must serve proof/decision-making, not decoration only.
+- Principle II (Retro + usability): Motion must be subtle and accessible.
+- Principle IV (Lightweight): No heavy animation libs by default; prefer CSS/SVG.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/[###-feature]/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+<!--
+  ACTION REQUIRED: Replace the placeholder tree below with the concrete layout
+  for this feature. Delete unused options and expand the chosen structure with
+  real paths (e.g., apps/admin, packages/something). The delivered plan must
+  not include Option labels.
+-->
+
+```text
+src/
+├── app/
+│   ├── globals.css              # motion + image helpers
+│   └── page.tsx
+├── components/
+│   ├── sections/WorkSection.tsx # add visuals
+│   └── ...other components
+└── content/portfolio.ts         # optional asset metadata
+
+public/
+└── assets/                      # new diagrams/pixel art (svg/png/webp)
+```
+
+**Structure Decision**: `public/assets/` に静的アセットを追加し、`WorkSection` で表示する。
+モーションは `globals.css` と Tailwind class を中心に実装し、Client Component化は最小限に抑える。
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| [e.g., 4th project] | [current need] | [why 3 projects insufficient] |
+| [e.g., Repository pattern] | [specific problem] | [why direct DB access insufficient] |

--- a/specs/021-gamefeel/quickstart.md
+++ b/specs/021-gamefeel/quickstart.md
@@ -1,0 +1,34 @@
+# Quickstart: Gamefeel Upgrade (Images/Diagrams + Retro Motion)
+
+**Feature**: `specs/021-gamefeel/spec.md`  
+**Date**: 2025-12-28
+
+## Run locally
+
+```bash
+cd /Users/takeshiwatanabe/EureWorks/private/git/portfolio
+pnpm dev
+```
+
+## Verify visuals
+
+1. Open `http://localhost:3000`
+2. Scroll to **Work**
+3. Confirm at least one Project card shows a visual (diagram/screenshot/pixel icon)
+4. Confirm images do not break the layout on mobile width
+
+## Verify motion (accessibility)
+
+1. With normal settings, confirm subtle motion exists (blink/float/hover)
+2. Enable reduced motion:
+   - macOS: System Settings → Accessibility → Display → Reduce motion
+3. Reload and confirm motion is suppressed
+
+## Quality gates
+
+```bash
+pnpm lint
+pnpm build
+```
+
+

--- a/specs/021-gamefeel/research.md
+++ b/specs/021-gamefeel/research.md
@@ -1,0 +1,50 @@
+# Research: Gamefeel Upgrade (Images/Diagrams + Retro Motion)
+
+**Feature**: `specs/021-gamefeel/spec.md`  
+**Date**: 2025-12-28
+
+## Decisions
+
+### Decision: Use static assets + SVG/PNG in `public/assets/` (no external CDNs)
+
+- **Chosen**: Add a small set of curated images/diagrams under `public/assets/` and render them in `WorkSection`.
+- **Rationale**:
+  - No runtime dependency needed; Vercel serves `public/` efficiently.
+  - Keeps “proof” close to the written narrative.
+  - Avoids operational complexity (no upload pipeline).
+- **Alternatives considered**:
+  - External image hosting/CDN (rejected: ops + privacy risk).
+
+### Decision: Prefer `next/image` for raster images; use plain `<img>` for SVG when convenient
+
+- **Chosen**:
+  - Use `next/image` for PNG/WebP screenshots or thumbnails (optimization + sizing).
+  - Use `<img src="/assets/foo.svg">` for lightweight diagrams/pixel icons (simple and stable).
+- **Rationale**:
+  - Keeps bundle small; avoids complex SVG import pipelines.
+
+### Decision: Motion is CSS-first + reduced-motion safe
+
+- **Chosen**:
+  - Use subtle CSS animations (blink, float, step-based pixel wiggle) with small durations.
+  - Gate with `@media (prefers-reduced-motion: reduce)` to disable or reduce to non-animated state.
+- **Rationale**:
+  - Aligns with constitution: lightweight + usable.
+  - Avoids JS-driven scroll animations that can cause jank.
+- **Alternatives considered**:
+  - Lottie/GSAP (rejected: dependency weight + accessibility complexity).
+
+### Decision: Where visuals go (scope)
+
+- **Chosen**:
+  - Add an optional `asset` to each Project in `src/content/portfolio.ts` (thumbnail/diagram).
+  - Render a thumbnail area inside each Project card.
+  - Add one or two small “gamefeel” touches in Hero/Menu/Work (blink/hover) only.
+- **Rationale**: Focus on proof + tasteful polish; avoid turning the site into an effects demo.
+
+## Open Questions (to resolve during implementation)
+
+- Exact asset list: which projects get which diagrams/screenshots first?
+- Asset format preference: SVG-only vs mix of SVG + WebP.
+
+

--- a/specs/021-gamefeel/spec.md
+++ b/specs/021-gamefeel/spec.md
@@ -1,0 +1,114 @@
+# Feature Specification: Gamefeel Upgrade (Images/Diagrams + Retro Motion)
+
+**Feature Branch**: `021-gamefeel`  
+**Created**: 2025-12-28  
+**Status**: Draft  
+**Input**: User description: "雰囲気を残しつつ、図や画像やゲームらしい動きを入れてクオリティを上げたい。"
+
+## User Scenarios & Testing *(mandatory)*
+
+<!--
+  IMPORTANT: User stories should be PRIORITIZED as user journeys ordered by importance.
+  Each user story/journey must be INDEPENDENTLY TESTABLE - meaning if you implement just ONE of them,
+  you should still have a viable MVP (Minimum Viable Product) that delivers value.
+  
+  Assign priorities (P1, P2, P3, etc.) to each story, where P1 is the most critical.
+  Think of each story as a standalone slice of functionality that can be:
+  - Developed independently
+  - Tested independently
+  - Deployed independently
+  - Demonstrated to users independently
+-->
+
+### User Story 1 - Visual proof assets (Priority: P1)
+
+訪問者として、文章だけでなく図/画像があることで、理解が早く・印象に残る形で Work/Projects を読めるようにしたい。
+
+**Why this priority**: Portfolioは初見の理解速度が価値。画像/図は最短で伝わる“証拠”になる。
+
+**Independent Test**: `pnpm dev` → Workセクションの少なくとも1つのProjectに画像/図が表示され、リンク/レイアウトが崩れない。
+
+**Acceptance Scenarios**:
+
+1. **Given** トップページを開く、**When** Workを読む、**Then** Projectカードにサムネイル/図が表示される
+2. **Given** 画像が読み込めない/存在しない、**When** 表示する、**Then** 代替（プレースホルダ/alt）がありレイアウトが壊れない
+
+---
+
+### User Story 2 - Game-like micro motion (Priority: P2)
+
+訪問者として、レトロ雰囲気を損なわずに“ゲームっぽい動き”があることで、触って楽しい・記憶に残る体験にしたい。
+
+**Why this priority**: “雰囲気”の強化が差別化要因になり、滞在/スクロールを促す。
+
+**Independent Test**: 主要UIに軽量なモーションが追加され、`prefers-reduced-motion` では無効化される。
+
+**Acceptance Scenarios**:
+
+1. **Given** 標準設定、**When** Hero/Menu/Work を見る、**Then** 目立ちすぎないレトロなモーションが確認できる
+2. **Given** `prefers-reduced-motion: reduce`、**When** 表示する、**Then** モーションが抑制される（静的に見える）
+
+---
+
+### User Story 3 - Quality + performance guardrails (Priority: P3)
+
+運用者として、画像/モーション追加でサイトが重くならず、Next.js/Vercelで安全に運用できる形にしたい。
+
+**Why this priority**: パフォーマンス劣化はユーザー体験のバグ。特にモバイルで顕著。
+
+**Independent Test**: `pnpm lint` と `pnpm build` が通り、画像は最適化され、モーションはCSS中心で軽量。
+
+**Acceptance Scenarios**:
+
+1. **Given** 変更後、**When** `pnpm build`、**Then** ビルドが成功する
+2. **Given** 画像が多いページ、**When** スクロール、**Then** 体感で引っかかりが増えない（過度なアニメ/JSを避ける）
+
+---
+
+[Add more user stories as needed, each with an assigned priority]
+
+### Edge Cases
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right edge cases.
+-->
+
+- 画像が未設定/ファイルが欠けている場合
+- SVG/PNG/WebP など形式差が混在する場合
+- `prefers-reduced-motion` での挙動
+- モバイル（低スペック）での描画負荷（アニメの多用/影/ぼかし）
+- 外部リンクの安全性（target/rel）
+
+## Requirements *(mandatory)*
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right functional requirements.
+-->
+
+### Functional Requirements
+
+- **FR-001**: システム MUST Work/Projects に図や画像（サムネ/ダイアグラム）を表示できる
+- **FR-002**: システム MUST 画像が欠けても壊れない（代替表示/レイアウト維持）
+- **FR-003**: システム MUST “ゲームらしい動き”を追加する（CSS中心、過度な演出は避ける）
+- **FR-004**: システム MUST `prefers-reduced-motion` に従いモーションを抑制できる
+- **FR-005**: システム MUST パフォーマンスを悪化させない（大きなJS追加・重いアニメを避ける）
+
+### Key Entities *(include if feature involves data)*
+
+- **Asset**: 画像/図のメタ（src, alt, kind）
+- **MotionPreset**: UIで使うモーション（name, duration, reducedMotionBehavior）
+
+## Success Criteria *(mandatory)*
+
+<!--
+  ACTION REQUIRED: Define measurable success criteria.
+  These must be technology-agnostic and measurable.
+-->
+
+### Measurable Outcomes
+
+- **SC-001**: Work内の少なくとも1つのProjectに画像/図が表示される
+- **SC-002**: `prefers-reduced-motion` 有効時、主要なモーションが抑制される
+- **SC-003**: `pnpm lint` と `pnpm build` が通る

--- a/specs/021-gamefeel/tasks.md
+++ b/specs/021-gamefeel/tasks.md
@@ -1,0 +1,112 @@
+---
+description: "Tasks for 021-gamefeel"
+---
+
+# Tasks: Gamefeel Upgrade (Images/Diagrams + Retro Motion)
+
+**Input**: Design documents from `/Users/takeshiwatanabe/EureWorks/private/git/portfolio/specs/021-gamefeel/`  
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/`, `quickstart.md`
+
+**Tests**: No automated tests requested; verify via `pnpm dev` + `pnpm lint` + `pnpm build`.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm repo health and create asset folders.
+
+- [X] T001 Confirm baseline quality gates: run `pnpm lint` and `pnpm build` in `/Users/takeshiwatanabe/EureWorks/private/git/portfolio/`
+- [X] T002 Create static asset directories `public/assets/diagrams/` and `public/assets/pixel/` in `/Users/takeshiwatanabe/EureWorks/private/git/portfolio/public/`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Introduce the minimal data model and CSS primitives needed by all stories.
+
+- [X] T003 Add `Asset` type and optional `Project.asset?: Asset` in `src/content/portfolio.ts`
+- [X] T004 Add CSS motion utility classes and reduced-motion gating in `src/app/globals.css` (e.g. `.pixel-float`, `.blink-soft`, `@media (prefers-reduced-motion: reduce)`)
+
+**Checkpoint**: TypeScript builds; no UI changes required yet.
+
+---
+
+## Phase 3: User Story 1 - Visual proof assets (Priority: P1) 🎯 MVP
+
+**Goal**: Show at least one diagram/screenshot on a Project card inside Work.
+
+**Independent Test**: `pnpm dev` → Work → at least one Project card shows a visual; removing the asset does not break layout.
+
+- [X] T005 [P] [US1] Add at least one real asset file under `public/assets/diagrams/` (e.g. `public/assets/diagrams/go-migration.svg`)
+- [X] T006 [P] [US1] Add `asset` metadata to at least one Project in `src/content/portfolio.ts` (src/alt/kind; width/height if raster)
+- [X] T007 [US1] Render `project.asset` in `src/components/sections/WorkSection.tsx` with graceful fallback (diagram via `<img>`, raster via `next/image` if used)
+- [X] T008 [US1] Ensure accessibility: meaningful `alt` text and no layout shift on mobile in `src/components/sections/WorkSection.tsx`
+
+**Checkpoint**: SC-001 satisfied.
+
+---
+
+## Phase 4: User Story 2 - Game-like micro motion (Priority: P2)
+
+**Goal**: Add subtle retro motion that is suppressed under reduced-motion.
+
+**Independent Test**: With normal settings, see subtle motion; with reduced motion enabled, animations stop.
+
+- [X] T009 [US2] Apply subtle motion classes to one or two elements (Hero/Menu/Work) in `src/components/Hero.tsx`, `src/components/TableOfContents.tsx`, or `src/components/sections/WorkSection.tsx`
+- [X] T010 [US2] Verify reduced-motion behavior by ensuring animated elements have a stable non-animated baseline (CSS in `src/app/globals.css`)
+
+**Checkpoint**: SC-002 satisfied.
+
+---
+
+## Phase 5: User Story 3 - Quality + performance guardrails (Priority: P3)
+
+**Goal**: Keep the site fast and retro; avoid heavy runtime deps and janky animations.
+
+**Independent Test**: `pnpm build` passes; assets are appropriately sized; no large JS animation libs are introduced.
+
+- [X] T011 [US3] Ensure assets are optimized (prefer SVG or compressed WebP) and document any size constraints in `specs/021-gamefeel/contracts/README.md`
+- [X] T012 [US3] Audit motion for jank risks (no scroll-tied JS; avoid expensive filters) and adjust `src/app/globals.css` accordingly
+
+**Checkpoint**: SC-003 satisfied and no performance regressions introduced by design.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final verification, docs sync if needed, and quickstart validation.
+
+- [X] T013 Run `pnpm lint` and fix any issues introduced by new types/components
+- [X] T014 Run `pnpm build` and fix any issues
+- [X] T015 Validate `specs/021-gamefeel/quickstart.md` steps end-to-end
+- [X] T016 If top-level UX/docs changed (new assets guidance, motion guidance), update `README.md`, `AGENTS.md`, and `CLAUDE.md` together
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)** → **Foundational (Phase 2)** → **US1 (P1)** → **US2 (P2)** → **US3 (P3)** → **Polish (Phase 6)**
+
+### Parallel Opportunities
+
+- `T005` and `T006` can be done in parallel (assets + metadata)
+- Motion CSS (`T004`) can be developed in parallel with asset prep (`T005`) as long as it doesn’t depend on UI changes
+
+---
+
+## Parallel Example: User Story 1
+
+```text
+Task: T005 [P] [US1] Add an asset file under public/assets/diagrams/
+Task: T006 [P] [US1] Add project.asset metadata in src/content/portfolio.ts
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Add `Project.asset` data model (T003)
+2. Add one asset file (T005) and wire it into one Project (T006)
+3. Render the asset in WorkSection with fallback (T007–T008)

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -41,3 +41,42 @@ body {
     );
   background-blend-mode: screen;
 }
+
+/* Gamefeel: subtle, CSS-first motion (must respect reduced motion) */
+.pixel-float {
+  animation: pixel-float 1600ms ease-in-out infinite;
+  will-change: transform;
+}
+
+@keyframes pixel-float {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-3px);
+  }
+}
+
+.blink-soft {
+  animation: blink-soft 2200ms steps(2, end) infinite;
+}
+
+@keyframes blink-soft {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.55;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pixel-float,
+  .blink-soft {
+    animation: none !important;
+  }
+}
+
+/* Guardrail: avoid expensive animation patterns (keep transforms/opacity only). */

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -2,7 +2,7 @@ export function Hero() {
   return (
     <section className="frame bg-[#1b1b1b] p-8 text-center text-fami-ivory">
       <p
-        className="mb-3 text-xs uppercase tracking-[0.3em] text-fami-gold"
+        className="blink-soft mb-3 text-xs uppercase tracking-[0.3em] text-fami-gold"
         style={{ fontFamily: "var(--font-press)" }}
       >
         PRESS START

--- a/src/components/sections/WorkSection.tsx
+++ b/src/components/sections/WorkSection.tsx
@@ -1,4 +1,5 @@
 import { getPortfolio } from "@/content/portfolio";
+import Image from "next/image";
 
 function isExternalHttpHref(href: string) {
   return href.startsWith("http://") || href.startsWith("https://");
@@ -16,7 +17,7 @@ export async function WorkSection() {
         <h2 className="text-xl text-fami-gold" style={{ fontFamily: "var(--font-press)" }}>
           {work.heading}
         </h2>
-        <span className="text-xs uppercase tracking-[0.3em] text-fami-gold">WORK LOG</span>
+        <span className="pixel-float text-xs uppercase tracking-[0.3em] text-fami-gold">WORK LOG</span>
       </header>
 
       <p className="mt-3 text-sm [font-family:var(--font-noto)]">
@@ -77,6 +78,18 @@ export async function WorkSection() {
                     id={project.anchorId}
                     className="frame scroll-mt-[var(--menu-offset)] bg-[#1b1b1b] p-4"
                   >
+                    {project.asset ? (
+                      <div className="mb-3 overflow-hidden rounded-sm border-2 border-fami-gold/60 bg-[#111]">
+                        {/* Use next/image for optimization (even for SVG) */}
+                        <Image
+                          src={project.asset.src}
+                          alt={project.asset.alt}
+                          width={960}
+                          height={540}
+                          className="h-auto w-full object-contain"
+                        />
+                      </div>
+                    ) : null}
                     <div className="flex items-center justify-between gap-2">
                       <h4 className="text-sm text-fami-gold" style={{ fontFamily: "var(--font-press)" }}>
                         {project.title}

--- a/src/content/portfolio.ts
+++ b/src/content/portfolio.ts
@@ -11,6 +11,14 @@ export type ExternalLink = {
 
 export type Visibility = "public" | "private";
 
+export type Asset = {
+  src: string; // path under /public, e.g. "/assets/diagrams/go-migration.svg"
+  alt: string;
+  kind: "diagram" | "screenshot" | "pixel-art";
+  width?: number;
+  height?: number;
+};
+
 export type Project = {
   visibility?: Visibility; // default: "public"
   /**
@@ -23,6 +31,7 @@ export type Project = {
   role: string;
   tech: string[];
   outcomeOrLearning: string;
+  asset?: Asset;
   link?: ExternalLink;
   status?: string;
 };
@@ -157,6 +166,11 @@ export const publicPortfolio: Portfolio = {
             visibility: "public",
             anchorId: "project-go-migration",
             title: "Goによるバックエンド刷新",
+            asset: {
+              kind: "diagram",
+              src: "/assets/diagrams/go-migration.svg",
+              alt: "段階移行（切替/ロールバック前提）の概念図",
+            },
             summary:
               "課題: 既存システムの制約下での刷新。対応: 段階移行（切替/ロールバック前提）でリスクを抑えつつ置き換えを推進。",
             role: "Tech Lead / Backend",


### PR DESCRIPTION
### Summary
- Add optional `Project.asset` visuals rendered in Work projects
- Add subtle CSS-only motion (`blink-soft`, `pixel-float`) with `prefers-reduced-motion` support
- Add a first diagram asset under `public/assets/diagrams/`

### Verification
- pnpm lint
- pnpm build

Docs synced (README.md / AGENTS.md / CLAUDE.md).