### PR TITLE
UI: retro pixel icons

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,9 @@ Unified cheat sheet so any AI agent (Claude Code, GPT, etc.) can understand the 
   - Optional visuals:
     - Static assets live under `public/assets/`
     - Projects can optionally specify `project.asset` to render a diagram/thumbnail in Work
+  - Optional icons:
+    - Pixel-style icons live under `public/assets/pixel/icons/`
+    - Use `src/components/PixelIcon.tsx` for consistent sizing + decorative a11y defaults
   - Motion:
     - CSS-only motion utilities live in `src/app/globals.css` (e.g. reduced-motion aware helpers)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@ Focused tips for Anthropic Claude Code / Workbench agents interacting with this 
   - `PORTFOLIO_PRIVATE_JSON` (JSON string)
   - Skills use `years` (required) and can optionally include `firstUsedYear` / `lastUsedYear` (numeric years) to show recency.
 - `public/assets/` – Static diagrams/screenshots (optional); Projects can specify `project.asset` to render visuals.
+- `public/assets/pixel/icons/` – Pixel-style icon set (optional); use `src/components/PixelIcon.tsx`.
 - `src/app/globals.css` – Global palette + small CSS-only motion utilities (reduced-motion aware).
 - `src/app/layout.tsx` – Imports NES.css, fonts, metadata; extend when adding OG tags or global providers.
 - `tailwind.config.js` – Update `content` array if adding directories.

--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ When a change affects dependencies or workflows, remember to update README / doc
 - Add optional visuals to Projects:
   - Put diagrams/screenshots under `public/assets/`
   - Set `project.asset` in `src/content/portfolio.ts` to render a thumbnail/diagram in Work
+- Add optional retro icons:
+  - Put pixel-style icons under `public/assets/pixel/icons/`
+  - Use `src/components/PixelIcon.tsx` in headings/links (decorative by default; reduced a11y noise)
 - If you want to keep some details off the public repo, you can provide private overrides via
   environment variables (see `src/content/portfolio.ts`: `PORTFOLIO_PRIVATE_JSON`).
   - Projects can include `visibility: "public" | "private"`. Private items will be redacted

--- a/public/assets/pixel/icons/activities.svg
+++ b/public/assets/pixel/icons/activities.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" shape-rendering="crispEdges" role="img" aria-label="Activities icon">
+  <g fill="#d7b05b">
+    <!-- star -->
+    <rect x="11" y="4" width="2" height="6" />
+    <rect x="8" y="7" width="8" height="2" />
+    <rect x="10" y="10" width="4" height="2" />
+    <rect x="9" y="12" width="6" height="2" />
+    <!-- base -->
+    <rect x="9" y="16" width="6" height="2" />
+    <rect x="8" y="18" width="8" height="2" />
+  </g>
+</svg>
+
+

--- a/public/assets/pixel/icons/contact.svg
+++ b/public/assets/pixel/icons/contact.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" shape-rendering="crispEdges" role="img" aria-label="Contact icon">
+  <g fill="#d7b05b">
+    <!-- envelope -->
+    <rect x="5" y="8" width="14" height="2" />
+    <rect x="4" y="10" width="16" height="8" />
+    <!-- flap -->
+    <rect x="6" y="11" width="2" height="2" />
+    <rect x="8" y="12" width="2" height="2" />
+    <rect x="10" y="13" width="4" height="2" />
+    <rect x="14" y="12" width="2" height="2" />
+    <rect x="16" y="11" width="2" height="2" />
+  </g>
+</svg>
+
+

--- a/public/assets/pixel/icons/email.svg
+++ b/public/assets/pixel/icons/email.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" shape-rendering="crispEdges" role="img" aria-label="Email icon">
+  <g fill="#d7b05b">
+    <rect x="5" y="8" width="14" height="2" />
+    <rect x="4" y="10" width="16" height="8" />
+    <rect x="6" y="11" width="2" height="2" />
+    <rect x="8" y="12" width="2" height="2" />
+    <rect x="10" y="13" width="4" height="2" />
+    <rect x="14" y="12" width="2" height="2" />
+    <rect x="16" y="11" width="2" height="2" />
+  </g>
+</svg>
+
+

--- a/public/assets/pixel/icons/github.svg
+++ b/public/assets/pixel/icons/github.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" shape-rendering="crispEdges" role="img" aria-label="GitHub icon">
+  <g fill="#d7b05b">
+    <!-- simple pixel cat head -->
+    <rect x="7" y="7" width="2" height="2" />
+    <rect x="15" y="7" width="2" height="2" />
+    <rect x="6" y="9" width="12" height="2" />
+    <rect x="5" y="11" width="14" height="6" />
+    <!-- eyes -->
+    <rect x="8" y="13" width="2" height="2" />
+    <rect x="14" y="13" width="2" height="2" />
+    <!-- mouth -->
+    <rect x="11" y="15" width="2" height="2" />
+  </g>
+</svg>
+
+

--- a/public/assets/pixel/icons/linkedin.svg
+++ b/public/assets/pixel/icons/linkedin.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" shape-rendering="crispEdges" role="img" aria-label="LinkedIn icon">
+  <g fill="#d7b05b">
+    <!-- "in" blocky mark -->
+    <rect x="6" y="7" width="4" height="4" />
+    <rect x="6" y="12" width="4" height="6" />
+
+    <rect x="12" y="10" width="2" height="8" />
+    <rect x="14" y="9" width="4" height="2" />
+    <rect x="18" y="11" width="2" height="7" />
+  </g>
+</svg>
+
+

--- a/public/assets/pixel/icons/profile.svg
+++ b/public/assets/pixel/icons/profile.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" shape-rendering="crispEdges" role="img" aria-label="Profile icon">
+  <g fill="#d7b05b">
+    <!-- head -->
+    <rect x="10" y="4" width="4" height="4" />
+    <rect x="8" y="6" width="2" height="2" />
+    <rect x="14" y="6" width="2" height="2" />
+    <!-- shoulders -->
+    <rect x="7" y="10" width="10" height="2" />
+    <rect x="6" y="12" width="12" height="2" />
+    <rect x="5" y="14" width="14" height="2" />
+  </g>
+</svg>
+
+

--- a/public/assets/pixel/icons/skills.svg
+++ b/public/assets/pixel/icons/skills.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" shape-rendering="crispEdges" role="img" aria-label="Skills icon">
+  <g fill="#d7b05b">
+    <!-- wrench-ish -->
+    <rect x="6" y="6" width="4" height="2" />
+    <rect x="4" y="8" width="4" height="2" />
+    <rect x="8" y="8" width="2" height="2" />
+    <rect x="10" y="10" width="2" height="2" />
+    <rect x="12" y="12" width="2" height="2" />
+    <rect x="14" y="14" width="2" height="2" />
+    <rect x="16" y="16" width="2" height="2" />
+    <rect x="15" y="18" width="4" height="2" />
+  </g>
+</svg>
+
+

--- a/public/assets/pixel/icons/work.svg
+++ b/public/assets/pixel/icons/work.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" shape-rendering="crispEdges" role="img" aria-label="Work icon">
+  <g fill="#d7b05b">
+    <!-- handle -->
+    <rect x="9" y="6" width="6" height="2" />
+    <rect x="8" y="8" width="8" height="2" />
+    <!-- case body -->
+    <rect x="5" y="10" width="14" height="2" />
+    <rect x="4" y="12" width="16" height="6" />
+    <!-- latch -->
+    <rect x="11" y="13" width="2" height="2" />
+  </g>
+</svg>
+
+

--- a/public/assets/pixel/icons/writing.svg
+++ b/public/assets/pixel/icons/writing.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" shape-rendering="crispEdges" role="img" aria-label="Writing icon">
+  <g fill="#d7b05b">
+    <!-- pencil body -->
+    <rect x="6" y="16" width="12" height="2" transform="rotate(-45 12 17)" />
+    <rect x="8" y="14" width="12" height="2" transform="rotate(-45 14 15)" />
+    <!-- tip -->
+    <rect x="16" y="6" width="2" height="2" />
+    <rect x="18" y="4" width="2" height="2" />
+    <!-- tail -->
+    <rect x="6" y="18" width="2" height="2" />
+  </g>
+</svg>
+
+

--- a/public/assets/pixel/icons/x.svg
+++ b/public/assets/pixel/icons/x.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" shape-rendering="crispEdges" role="img" aria-label="X icon">
+  <g fill="#d7b05b">
+    <rect x="6" y="7" width="2" height="2" />
+    <rect x="16" y="7" width="2" height="2" />
+    <rect x="8" y="9" width="2" height="2" />
+    <rect x="14" y="9" width="2" height="2" />
+    <rect x="10" y="11" width="4" height="2" />
+    <rect x="8" y="13" width="2" height="2" />
+    <rect x="14" y="13" width="2" height="2" />
+    <rect x="6" y="15" width="2" height="2" />
+    <rect x="16" y="15" width="2" height="2" />
+  </g>
+</svg>
+
+

--- a/specs/022-retro-icons/contracts/README.md
+++ b/specs/022-retro-icons/contracts/README.md
@@ -1,0 +1,23 @@
+# Contracts: Retro icon assets (internal)
+
+**Feature**: `specs/022-retro-icons/spec.md`  
+**Date**: 2025-12-28
+
+## Purpose
+
+Define internal conventions for icon assets and rendering.
+
+## Asset contract
+
+- All icons MUST live under `public/assets/pixel/icons/`
+- Prefer SVG
+- Filenames SHOULD be kebab-case and semantic (e.g. `work.svg`, `skills.svg`, `github.svg`)
+
+## Accessibility contract
+
+- Decorative icons MUST be rendered with:
+  - `alt=""`
+  - `aria-hidden="true"`
+- If an icon conveys meaning not present in adjacent text, it MUST have meaningful `alt`.
+
+

--- a/specs/022-retro-icons/data-model.md
+++ b/specs/022-retro-icons/data-model.md
@@ -1,0 +1,29 @@
+# Data Model: Retro icons
+
+**Feature**: `specs/022-retro-icons/spec.md`  
+**Date**: 2025-12-28
+
+## Overview
+
+This feature adds optional retro icon assets and uses them in headings and link lists.
+
+## Entities
+
+### `IconAsset`
+
+- `src`: string (path under `public/`, e.g. `"/assets/pixel/icons/work.svg"`)
+- `alt`: string (use `""` for decorative icons)
+- `size`: `"sm" | "md"` (maps to pixel sizes in UI)
+- `decorative`: boolean (when true, render with `aria-hidden` and `alt=""`)
+
+### `IconPlacement`
+
+- Section heading icons (Profile/Work/Writing/Activities/Skills/Contact)
+- Contact link icons (Email/GitHub/X/LinkedIn)
+
+## Rendering Rules
+
+- Decorative icons MUST NOT be read by screen readers (`aria-hidden="true"` and `alt=""`).
+- Icons MUST have consistent sizing and alignment to avoid layout jitter on mobile.
+
+

--- a/specs/022-retro-icons/plan.md
+++ b/specs/022-retro-icons/plan.md
@@ -1,0 +1,94 @@
+# Implementation Plan: Retro Icon Pack (UI icons)
+
+**Branch**: `022-retro-icons` | **Date**: 2025-12-28 | **Spec**: `specs/022-retro-icons/spec.md`
+**Input**: Feature specification from `specs/022-retro-icons/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/commands/plan.md` for the execution workflow.
+
+## Summary
+
+Retroな雰囲気を保ったまま、セクション見出し・Contactリンクなどにピクセル調のアイコンを追加して
+UIのスキャン性と“ゲームっぽさ”を上げる。アイコンは `public/assets/pixel/icons/` に集約し、
+SVG中心・アクセシビリティ（decorative alt/aria）を守る。
+
+## Technical Context
+
+<!--
+  ACTION REQUIRED: Replace the content in this section with the technical details
+  for the project. The structure here is presented in advisory capacity to guide
+  the iteration process.
+-->
+
+**Language/Version**: TypeScript 5.x (Next.js App Router)  
+**Primary Dependencies**: Next.js 16, React 19, Tailwind CSS 3, NES.css  
+**Storage**: N/A (static SVG assets under `public/`)  
+**Testing**: N/A (no automated tests; rely on `pnpm lint` + `pnpm build`)  
+**Target Platform**: Vercel  
+**Project Type**: Web application (Next.js App Router under `src/`)  
+**Performance Goals**: SVG-first; keep icon count small; avoid new runtime deps  
+**Constraints**: Retro aesthetic + readability; icons must not harm accessibility (alt/aria)  
+**Scale/Scope**: A curated icon set (not an icon library)
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Use `.specify/memory/constitution.md` as the source of truth. This repo’s default
+gates (adapt per feature) are:
+
+- Principle compliance: changes support “Personality-First Storytelling” and do not
+  dilute the retro aesthetic + usability balance.
+- Quality gates: `pnpm lint` and `pnpm build` pass.
+- Docs sync: if dependencies/scripts/runtime/deploy/top-level UX change, update
+  `README.md`, `AGENTS.md`, and `CLAUDE.md` together.
+
+**Gate Evaluation (pre-research)**:
+- Principle II (Retro + usability): icons enhance hierarchy; must not reduce readability.
+- Principle IV (Lightweight): no new icon packs or heavy deps; use a small curated SVG set.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/[###-feature]/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+<!--
+  ACTION REQUIRED: Replace the placeholder tree below with the concrete layout
+  for this feature. Delete unused options and expand the chosen structure with
+  real paths (e.g., apps/admin, packages/something). The delivered plan must
+  not include Option labels.
+-->
+
+```text
+src/
+├── app/
+│   └── globals.css                 # optional icon sizing helpers
+├── components/
+│   ├── PixelIcon.tsx               # NEW helper component (wrap next/image)
+│   └── sections/*                  # add icons to headings and link lists
+└── content/portfolio.ts
+
+public/
+└── assets/pixel/icons/             # NEW pixel-style SVG icons
+```
+
+**Structure Decision**: `public/assets/pixel/icons/` にSVGを置き、`PixelIcon` で表示する。
+適用箇所は「見出し」「Contactリンク」に限定し、うるさくなりすぎないようにする。
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| [e.g., 4th project] | [current need] | [why 3 projects insufficient] |
+| [e.g., Repository pattern] | [specific problem] | [why direct DB access insufficient] |

--- a/specs/022-retro-icons/quickstart.md
+++ b/specs/022-retro-icons/quickstart.md
@@ -1,0 +1,28 @@
+# Quickstart: Retro Icon Pack
+
+**Feature**: `specs/022-retro-icons/spec.md`  
+**Date**: 2025-12-28
+
+## Run locally
+
+```bash
+cd /Users/takeshiwatanabe/EureWorks/private/git/portfolio
+pnpm dev
+```
+
+## Verify
+
+1. Open `http://localhost:3000`
+2. Confirm section headings show pixel icons:
+   - Profile / Work / Writing / Activities / Skills / Contact
+3. Confirm Contact link list shows icons and remains readable on mobile.
+4. Enable a screen reader and ensure decorative icons are not announced.
+
+## Quality gates
+
+```bash
+pnpm lint
+pnpm build
+```
+
+

--- a/specs/022-retro-icons/research.md
+++ b/specs/022-retro-icons/research.md
@@ -1,0 +1,38 @@
+# Research: Retro Icon Pack (UI icons)
+
+**Feature**: `specs/022-retro-icons/spec.md`  
+**Date**: 2025-12-28
+
+## Decisions
+
+### Decision: Use a small curated SVG icon set under `public/assets/pixel/icons/`
+
+- **Chosen**: Hand-authored (or carefully sourced) pixel-style SVG icons committed under `public/assets/pixel/icons/`.
+- **Rationale**:
+  - No new dependencies; aligns with “Lightweight, Fast, Durable”.
+  - SVG scales cleanly and is small.
+  - Centralizes assets and avoids “random icons everywhere” drift.
+- **Alternatives considered**:
+  - Large icon packs (rejected: weight, inconsistent style, licensing uncertainty).
+  - Webfont icons (rejected: rendering + accessibility tradeoffs).
+
+### Decision: Render icons via a tiny `PixelIcon` wrapper (uses `next/image`)
+
+- **Chosen**: Introduce `src/components/PixelIcon.tsx` that renders icons from `/public` with consistent sizing and accessibility defaults.
+- **Rationale**:
+  - Keeps icon usage consistent across sections.
+  - Easy to enforce `alt` vs decorative `aria-hidden`.
+
+### Decision: Where icons go (scope)
+
+- **Chosen**:
+  - Section headings: Profile/Work/Writing/Activities/Skills/Contact
+  - Contact links: Email/GitHub/X/LinkedIn
+- **Rationale**: High signal, low noise; improves scanability without cluttering the UI.
+
+## Open Questions
+
+- Exact icon list/visual language (16px vs 24px grid, outline thickness)
+- License/source policy if any non-handmade icon is used
+
+

--- a/specs/022-retro-icons/spec.md
+++ b/specs/022-retro-icons/spec.md
@@ -1,0 +1,118 @@
+# Feature Specification: Retro Icon Pack (UI icons)
+
+**Feature Branch**: `022-retro-icons`  
+**Created**: 2025-12-28  
+**Status**: Draft  
+**Input**: User description: "アイコン画像を増やしたい。もちろんレトロなアイコン。"
+
+## User Scenarios & Testing *(mandatory)*
+
+<!--
+  IMPORTANT: User stories should be PRIORITIZED as user journeys ordered by importance.
+  Each user story/journey must be INDEPENDENTLY TESTABLE - meaning if you implement just ONE of them,
+  you should still have a viable MVP (Minimum Viable Product) that delivers value.
+  
+  Assign priorities (P1, P2, P3, etc.) to each story, where P1 is the most critical.
+  Think of each story as a standalone slice of functionality that can be:
+  - Developed independently
+  - Tested independently
+  - Deployed independently
+  - Demonstrated to users independently
+-->
+
+### User Story 1 - Section icons (Priority: P1)
+
+訪問者として、各セクションを一目で識別できるように、レトロなアイコンが見出しに付いていてほしい。
+
+**Why this priority**: スクロール中の「どこを読んでいるか」の認知負荷を下げ、記憶に残る。
+
+**Independent Test**: `pnpm dev` → Profile/Work/Writing/Activities/Skills/Contact の見出しにピクセルアイコンが表示される。
+
+**Acceptance Scenarios**:
+
+1. **Given** トップページ、**When** セクション見出しを見る、**Then** 見出し左にレトロなアイコンが表示される
+2. **Given** 画面幅が小さい、**When** 表示する、**Then** アイコンが潰れず、文字の可読性が落ちない
+
+---
+
+### User Story 2 - Link icons (Priority: P2)
+
+訪問者として、Contact や外部リンクが“どこへ行くリンクか”直感的に分かるよう、アイコン付きで表示されてほしい。
+
+**Why this priority**: 外部遷移への不安を減らし、クリック率を上げる（分かりやすさ）。
+
+**Independent Test**: Contact のリンク（Email/GitHub/X/LinkedIn）がアイコン付きで表示され、キーボード操作でも破綻しない。
+
+**Acceptance Scenarios**:
+
+1. **Given** Contact セクション、**When** リンクを見る、**Then** ラベルの左にアイコンが付く
+2. **Given** スクリーンリーダー、**When** 読み上げる、**Then** 装飾アイコンがノイズにならない（alt/ariaが適切）
+
+---
+
+### User Story 3 - Asset & accessibility guardrails (Priority: P3)
+
+運用者として、アイコン追加でサイトが重くならず、アクセシビリティも担保したい。
+
+**Why this priority**: 小さな改善でも“積み上げ”で重くなる。ルール化して劣化を防ぐ。
+
+**Independent Test**: `pnpm lint` と `pnpm build` が通り、アイコンは `public/assets/pixel/icons/` 配下で一元管理される。
+
+**Acceptance Scenarios**:
+
+1. **Given** アイコン追加後、**When** `pnpm build`、**Then** 成功する
+2. **Given** アイコンファイルが欠けている、**When** 表示する、**Then** レイアウトが壊れない（必要ならフォールバック）
+
+---
+
+[Add more user stories as needed, each with an assigned priority]
+
+### Edge Cases
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right edge cases.
+-->
+
+- アイコンのパスが間違っている/ファイルが欠けている
+- 装飾アイコンの alt が読み上げのノイズになる
+- アイコンが増えすぎて UI がうるさくなる（適用箇所の節度）
+- モバイル表示でアイコンが潰れる
+
+## Requirements *(mandatory)*
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right functional requirements.
+-->
+
+### Functional Requirements
+
+- **FR-001**: システム MUST セクション見出しにレトロアイコンを表示できる
+- **FR-002**: システム MUST Contact 等のリンクにレトロアイコンを表示できる
+- **FR-003**: システム MUST アイコンを `public/assets/pixel/icons/` 配下で管理する
+- **FR-004**: システム MUST 装飾アイコンのアクセシビリティを担保する（alt/aria）
+- **FR-005**: システム MUST パフォーマンスを悪化させない（SVG中心、過剰に増やさない）
+
+*Example of marking unclear requirements:*
+
+- **FR-006**: System MUST authenticate users via [NEEDS CLARIFICATION: auth method not specified - email/password, SSO, OAuth?]
+- **FR-007**: System MUST retain user data for [NEEDS CLARIFICATION: retention period not specified]
+
+### Key Entities *(include if feature involves data)*
+
+- **IconAsset**: レトロアイコン（src, alt, size）
+- **IconPlacement**: どこに表示するか（section heading, contact link, etc）
+
+## Success Criteria *(mandatory)*
+
+<!--
+  ACTION REQUIRED: Define measurable success criteria.
+  These must be technology-agnostic and measurable.
+-->
+
+### Measurable Outcomes
+
+- **SC-001**: 主要セクション（Profile/Work/Writing/Activities/Skills/Contact）の見出しにアイコンが付く
+- **SC-002**: Contact リンクにアイコンが付く
+- **SC-003**: `pnpm lint` と `pnpm build` が通る

--- a/specs/022-retro-icons/tasks.md
+++ b/specs/022-retro-icons/tasks.md
@@ -1,0 +1,110 @@
+---
+description: "Tasks for 022-retro-icons"
+---
+
+# Tasks: Retro Icon Pack (UI icons)
+
+**Input**: Design documents from `/Users/takeshiwatanabe/EureWorks/private/git/portfolio/specs/022-retro-icons/`  
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/`, `quickstart.md`
+
+**Tests**: No automated tests requested; verify via `pnpm dev` + `pnpm lint` + `pnpm build`.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm baseline build health and create icon directories.
+
+- [X] T001 Confirm baseline quality gates: run `pnpm lint` and `pnpm build` in `/Users/takeshiwatanabe/EureWorks/private/git/portfolio/`
+- [X] T002 Create icon asset directory `public/assets/pixel/icons/` in `/Users/takeshiwatanabe/EureWorks/private/git/portfolio/public/`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Add a small reusable icon component with accessibility defaults.
+
+- [X] T003 Add `src/components/PixelIcon.tsx` (renders SVG from `/public`, supports `decorative`/`alt`, size `sm|md`)
+- [X] T004 Add optional sizing helpers in `src/app/globals.css` (e.g. `.pixel-icon-sm`, `.pixel-icon-md`) OR use Tailwind classes consistently (choose one)
+
+**Checkpoint**: `PixelIcon` can be used in any section without layout shift and without screen reader noise.
+
+---
+
+## Phase 3: User Story 1 - Section icons (Priority: P1) 🎯 MVP
+
+**Goal**: Add retro icons to the main section headings for scanability.
+
+**Independent Test**: `pnpm dev` → Profile/Work/Writing/Activities/Skills/Contact headings show a pixel icon left of the heading and remain readable on mobile.
+
+- [X] T005 [P] [US1] Add heading icon SVGs under `public/assets/pixel/icons/`: `profile.svg`, `work.svg`, `writing.svg`, `activities.svg`, `skills.svg`, `contact.svg`
+- [X] T006 [US1] Add icons to section headings by updating these files to render `PixelIcon` next to the `<h2>`:
+  - `src/components/sections/ProfileSection.tsx`
+  - `src/components/sections/WorkSection.tsx`
+  - `src/components/sections/WritingSection.tsx`
+  - `src/components/sections/ActivitiesSection.tsx`
+  - `src/components/sections/SkillsSection.tsx`
+  - `src/components/sections/ContactSection.tsx`
+- [X] T007 [US1] Ensure icons are decorative (no SR noise): set `decorative` or `alt=""` + `aria-hidden` via `PixelIcon`
+
+**Checkpoint**: SC-001 satisfied.
+
+---
+
+## Phase 4: User Story 2 - Link icons (Priority: P2)
+
+**Goal**: Add icons to Contact links for faster recognition.
+
+**Independent Test**: `pnpm dev` → Contact link list shows icons for Email/GitHub/X/LinkedIn; keyboard focus order remains sensible.
+
+- [X] T008 [P] [US2] Add link icon SVGs under `public/assets/pixel/icons/`: `email.svg`, `github.svg`, `x.svg`, `linkedin.svg`
+- [X] T009 [US2] Update `src/components/sections/ContactSection.tsx` to render `PixelIcon` in each link row (icon + label)
+- [X] T010 [US2] Ensure link icons are decorative and do not change link accessible name
+
+**Checkpoint**: SC-002 satisfied.
+
+---
+
+## Phase 5: User Story 3 - Asset & accessibility guardrails (Priority: P3)
+
+**Goal**: Keep icon usage lightweight, consistent, and accessible.
+
+**Independent Test**: `pnpm lint`/`pnpm build` pass; icons missing do not crash layout; docs/contracts clearly describe rules.
+
+- [X] T011 [US3] Enforce a safe fallback in `PixelIcon` when icon file is missing (e.g., render nothing but keep spacing stable)
+- [X] T012 [US3] Document naming + a11y rules in `specs/022-retro-icons/contracts/README.md` (confirm it matches actual implementation)
+
+**Checkpoint**: SC-003 satisfied.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final verification + docs sync (top-level UX change).
+
+- [X] T013 Run `pnpm lint` and fix any issues
+- [X] T014 Run `pnpm build` and fix any issues
+- [X] T015 Validate `specs/022-retro-icons/quickstart.md` steps end-to-end
+- [X] T016 Docs sync: update `README.md`, `AGENTS.md`, and `CLAUDE.md` to mention icon assets location + `PixelIcon` usage
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)** → **Foundational (Phase 2)** → **US1 (P1)** → **US2 (P2)** → **US3 (P3)** → **Polish (Phase 6)**
+
+### Parallel Opportunities
+
+- `T005` and `T008` (adding SVG files) can be parallelized
+- Heading icon wiring (`T006`) is mostly sequential to avoid merge conflicts, but can be parallelized by splitting files across workers
+
+---
+
+## Parallel Example: User Story 1
+
+```text
+Task: T005 [P] [US1] Add section heading icon SVGs under public/assets/pixel/icons/
+Task: T006 [US1] Add icons to section headings in src/components/sections/*.tsx
+```
+
+

--- a/src/components/PixelIcon.tsx
+++ b/src/components/PixelIcon.tsx
@@ -1,0 +1,50 @@
+import Image from "next/image";
+
+export type PixelIconSize = "sm" | "md";
+
+type PixelIconProps = {
+  src: string;
+  /**
+   * Use "" for decorative icons.
+   * If `decorative` is true, `alt` is forced to "" and `aria-hidden` is set.
+   */
+  alt?: string;
+  size?: PixelIconSize;
+  decorative?: boolean;
+  className?: string;
+};
+
+const SIZE_PX: Record<PixelIconSize, number> = {
+  sm: 16,
+  md: 20,
+};
+
+export function PixelIcon({
+  src,
+  alt = "",
+  size = "md",
+  decorative = true,
+  className,
+}: PixelIconProps) {
+  const px = SIZE_PX[size];
+
+  // Guardrail: keep spacing stable even if the asset 404s.
+  // The wrapper reserves layout; the image might fail to load, but UI won't jump.
+  return (
+    <span
+      className={className}
+      style={{ width: px, height: px, display: "inline-block", verticalAlign: "text-bottom" }}
+      aria-hidden={decorative ? "true" : undefined}
+    >
+      <Image
+        src={src}
+        alt={decorative ? "" : alt}
+        width={px}
+        height={px}
+        className="h-full w-full select-none"
+      />
+    </span>
+  );
+}
+
+

--- a/src/components/TableOfContents.tsx
+++ b/src/components/TableOfContents.tsx
@@ -1,4 +1,22 @@
 import { TOC_ITEMS, tocHref } from "@/components/toc";
+import { PixelIcon } from "@/components/PixelIcon";
+
+function tocIconSrc(id: (typeof TOC_ITEMS)[number]["id"]) {
+  switch (id) {
+    case "profile":
+      return "/assets/pixel/icons/profile.svg";
+    case "work":
+      return "/assets/pixel/icons/work.svg";
+    case "writing":
+      return "/assets/pixel/icons/writing.svg";
+    case "activities":
+      return "/assets/pixel/icons/activities.svg";
+    case "skills":
+      return "/assets/pixel/icons/skills.svg";
+    case "contact":
+      return "/assets/pixel/icons/contact.svg";
+  }
+}
 
 export function TableOfContents() {
   return (
@@ -20,7 +38,10 @@ export function TableOfContents() {
               className="nes-btn is-primary is-small shrink-0 text-[0.7rem] uppercase tracking-wide focus:outline-none focus-visible:ring-4 focus-visible:ring-fami-gold focus-visible:ring-offset-4 focus-visible:ring-offset-[#111]"
               href={tocHref(item.id)}
             >
-              {item.label}
+              <span className="inline-flex items-center gap-2">
+                <PixelIcon src={tocIconSrc(item.id)} decorative size="sm" />
+                <span>{item.label}</span>
+              </span>
             </a>
           </li>
         ))}

--- a/src/components/sections/ActivitiesSection.tsx
+++ b/src/components/sections/ActivitiesSection.tsx
@@ -1,4 +1,5 @@
 import { getPortfolio } from "@/content/portfolio";
+import { PixelIcon } from "@/components/PixelIcon";
 
 function isExternalHttpHref(href: string) {
   return href.startsWith("http://") || href.startsWith("https://");
@@ -12,8 +13,12 @@ export async function ActivitiesSection() {
       id={activities.id}
       className="frame scroll-mt-[var(--menu-offset)] bg-[#1b1b1b] p-6 text-fami-ivory"
     >
-      <h2 className="text-xl text-fami-gold" style={{ fontFamily: "var(--font-press)" }}>
-        {activities.heading}
+      <h2
+        className="flex items-center gap-2 text-xl text-fami-gold"
+        style={{ fontFamily: "var(--font-press)" }}
+      >
+        <PixelIcon src="/assets/pixel/icons/activities.svg" decorative size="md" />
+        <span>{activities.heading}</span>
       </h2>
 
       <p className="mt-3 text-sm [font-family:var(--font-noto)]">

--- a/src/components/sections/ContactSection.tsx
+++ b/src/components/sections/ContactSection.tsx
@@ -1,4 +1,5 @@
 import { getPortfolio } from "@/content/portfolio";
+import { PixelIcon } from "@/components/PixelIcon";
 
 function isExternalHttpHref(href: string) {
   return href.startsWith("http://") || href.startsWith("https://");
@@ -6,13 +7,33 @@ function isExternalHttpHref(href: string) {
 
 export async function ContactSection() {
   const { contact } = await getPortfolio();
+
+  const iconSrcForLabel = (label: string): string | null => {
+    switch (label) {
+      case "Email":
+        return "/assets/pixel/icons/email.svg";
+      case "GitHub":
+        return "/assets/pixel/icons/github.svg";
+      case "X":
+        return "/assets/pixel/icons/x.svg";
+      case "LinkedIn":
+        return "/assets/pixel/icons/linkedin.svg";
+      default:
+        return null;
+    }
+  };
+
   return (
     <section
       id={contact.id}
       className="frame scroll-mt-[var(--menu-offset)] bg-[#1b1b1b] p-6 text-fami-ivory"
     >
-      <h2 className="text-xl text-fami-gold" style={{ fontFamily: "var(--font-press)" }}>
-        {contact.heading}
+      <h2
+        className="flex items-center gap-2 text-xl text-fami-gold"
+        style={{ fontFamily: "var(--font-press)" }}
+      >
+        <PixelIcon src="/assets/pixel/icons/contact.svg" decorative size="md" />
+        <span>{contact.heading}</span>
       </h2>
       <p className="mt-3 whitespace-pre-line text-sm [font-family:var(--font-noto)]">
         {contact.blurb}
@@ -20,6 +41,7 @@ export async function ContactSection() {
       <div className="mt-6 flex flex-wrap gap-3">
         {contact.links.map((link) => {
           const isExternal = isExternalHttpHref(link.href);
+          const iconSrc = iconSrcForLabel(link.label);
           return (
             <a
               key={link.href}
@@ -28,7 +50,10 @@ export async function ContactSection() {
               target={isExternal ? "_blank" : undefined}
               rel={isExternal ? "noreferrer" : undefined}
             >
-              {link.label}
+              <span className="inline-flex items-center gap-2">
+                {iconSrc ? <PixelIcon src={iconSrc} decorative size="sm" /> : null}
+                <span>{link.label}</span>
+              </span>
             </a>
           );
         })}

--- a/src/components/sections/ProfileSection.tsx
+++ b/src/components/sections/ProfileSection.tsx
@@ -1,4 +1,5 @@
 import { getPortfolio } from "@/content/portfolio";
+import { PixelIcon } from "@/components/PixelIcon";
 
 export async function ProfileSection() {
   const { profile } = await getPortfolio();
@@ -7,8 +8,12 @@ export async function ProfileSection() {
       id={profile.id}
       className="frame scroll-mt-[var(--menu-offset)] bg-[#1b1b1b] p-6 text-fami-ivory"
     >
-      <h2 className="text-xl text-fami-gold" style={{ fontFamily: "var(--font-press)" }}>
-        {profile.heading}
+      <h2
+        className="flex items-center gap-2 text-xl text-fami-gold"
+        style={{ fontFamily: "var(--font-press)" }}
+      >
+        <PixelIcon src="/assets/pixel/icons/profile.svg" decorative size="md" />
+        <span>{profile.heading}</span>
       </h2>
       <p className="mt-3 text-sm [font-family:var(--font-noto)]">{profile.body}</p>
     </section>

--- a/src/components/sections/SkillsSection.tsx
+++ b/src/components/sections/SkillsSection.tsx
@@ -1,4 +1,5 @@
 import { getPortfolio } from "@/content/portfolio";
+import { PixelIcon } from "@/components/PixelIcon";
 
 function formatYears(years: number) {
   if (Number.isInteger(years)) return `${years}y`;
@@ -27,8 +28,12 @@ export async function SkillsSection() {
       id={skills.id}
       className="frame scroll-mt-[var(--menu-offset)] bg-[#1b1b1b] p-6 text-fami-ivory"
     >
-      <h2 className="text-xl text-fami-gold" style={{ fontFamily: "var(--font-press)" }}>
-        {skills.heading}
+      <h2
+        className="flex items-center gap-2 text-xl text-fami-gold"
+        style={{ fontFamily: "var(--font-press)" }}
+      >
+        <PixelIcon src="/assets/pixel/icons/skills.svg" decorative size="md" />
+        <span>{skills.heading}</span>
       </h2>
       {categories ? (
         <div className="mt-4 space-y-6">

--- a/src/components/sections/WorkSection.tsx
+++ b/src/components/sections/WorkSection.tsx
@@ -1,5 +1,6 @@
 import { getPortfolio } from "@/content/portfolio";
 import Image from "next/image";
+import { PixelIcon } from "@/components/PixelIcon";
 
 function isExternalHttpHref(href: string) {
   return href.startsWith("http://") || href.startsWith("https://");
@@ -14,8 +15,12 @@ export async function WorkSection() {
       className="frame scroll-mt-[var(--menu-offset)] bg-[#1b1b1b] p-6 text-fami-ivory"
     >
       <header className="flex items-baseline justify-between">
-        <h2 className="text-xl text-fami-gold" style={{ fontFamily: "var(--font-press)" }}>
-          {work.heading}
+        <h2
+          className="flex items-center gap-2 text-xl text-fami-gold"
+          style={{ fontFamily: "var(--font-press)" }}
+        >
+          <PixelIcon src="/assets/pixel/icons/work.svg" decorative size="md" />
+          <span>{work.heading}</span>
         </h2>
         <span className="pixel-float text-xs uppercase tracking-[0.3em] text-fami-gold">WORK LOG</span>
       </header>

--- a/src/components/sections/WritingSection.tsx
+++ b/src/components/sections/WritingSection.tsx
@@ -1,4 +1,5 @@
 import { getPortfolio } from "@/content/portfolio";
+import { PixelIcon } from "@/components/PixelIcon";
 
 function isExternalHttpHref(href: string) {
   return href.startsWith("http://") || href.startsWith("https://");
@@ -11,8 +12,12 @@ export async function WritingSection() {
       id={writing.id}
       className="frame scroll-mt-[var(--menu-offset)] bg-[#1b1b1b] p-6 text-fami-ivory"
     >
-      <h2 className="text-xl text-fami-gold" style={{ fontFamily: "var(--font-press)" }}>
-        {writing.heading}
+      <h2
+        className="flex items-center gap-2 text-xl text-fami-gold"
+        style={{ fontFamily: "var(--font-press)" }}
+      >
+        <PixelIcon src="/assets/pixel/icons/writing.svg" decorative size="md" />
+        <span>{writing.heading}</span>
       </h2>
 
       <p className="mt-3 text-sm [font-family:var(--font-noto)]">


### PR DESCRIPTION
### Summary
- Add pixel-style icon set under `public/assets/pixel/icons/`
- Add `src/components/PixelIcon.tsx` (decorative by default, stable spacing)
- Add icons to section headings + Contact links
- Add icons to MENU buttons (TableOfContents)

### Verification
- pnpm lint
- pnpm build

Docs synced (README.md / AGENTS.md / CLAUDE.md).