### PR TITLE
UI: unify Activities link button sizing

### DIFF
--- a/specs/023-activities-link-buttons/contracts/README.md
+++ b/specs/023-activities-link-buttons/contracts/README.md
@@ -1,0 +1,5 @@
+# Contracts: N/A
+
+This feature is purely presentational (UI-only). No external APIs/contracts.
+
+

--- a/specs/023-activities-link-buttons/data-model.md
+++ b/specs/023-activities-link-buttons/data-model.md
@@ -1,0 +1,8 @@
+# Data Model: Activities link buttons
+
+**Feature**: `specs/023-activities-link-buttons/spec.md`  
+**Date**: 2025-12-28
+
+This feature is UI-only. No data model changes.
+
+

--- a/specs/023-activities-link-buttons/plan.md
+++ b/specs/023-activities-link-buttons/plan.md
@@ -1,0 +1,83 @@
+# Implementation Plan: Activities link button sizing unification
+
+**Branch**: `023-activities-link-buttons` | **Date**: 2025-12-28 | **Spec**: `specs/023-activities-link-buttons/spec.md`
+**Input**: Feature specification from `specs/023-activities-link-buttons/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/commands/plan.md` for the execution workflow.
+
+## Summary
+
+Activities のリンクボタンの見た目（サイズ/高さ/余白）を統一し、長いラベルでも折り返さず
+リストの見た目を整える。実装は `src/components/sections/ActivitiesSection.tsx` を中心に、
+必要なら `src/app/globals.css` に最小限の補助クラスを追加する。
+
+## Technical Context
+
+<!--
+  ACTION REQUIRED: Replace the content in this section with the technical details
+  for the project. The structure here is presented in advisory capacity to guide
+  the iteration process.
+-->
+
+**Language/Version**: TypeScript 5.x (Next.js App Router)  
+**Primary Dependencies**: Next.js 16, React 19, Tailwind CSS 3, NES.css  
+**Storage**: N/A  
+**Testing**: N/A (no automated tests; rely on `pnpm lint` + `pnpm build`)  
+**Target Platform**: Vercel  
+**Project Type**: Web application (Next.js App Router under `src/`)  
+**Performance Goals**: No new deps; CSS-only; no layout shift  
+**Constraints**: Retro aesthetic + modern usability; keep focus visibility; prevent label wrap  
+**Scale/Scope**: One section (Activities)
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Use `.specify/memory/constitution.md` as the source of truth. This repo’s default
+gates (adapt per feature) are:
+
+- Principle compliance: changes support “Personality-First Storytelling” and do not
+  dilute the retro aesthetic + usability balance.
+- Quality gates: `pnpm lint` and `pnpm build` pass.
+- Docs sync: if dependencies/scripts/runtime/deploy/top-level UX change, update
+  `README.md`, `AGENTS.md`, and `CLAUDE.md` together.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/[###-feature]/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+<!--
+  ACTION REQUIRED: Replace the placeholder tree below with the concrete layout
+  for this feature. Delete unused options and expand the chosen structure with
+  real paths (e.g., apps/admin, packages/something). The delivered plan must
+  not include Option labels.
+-->
+
+```text
+src/
+├── components/sections/ActivitiesSection.tsx
+└── app/globals.css (optional)
+```
+
+**Structure Decision**: `ActivitiesSection.tsx` のリンクボタンclassを共通化し、必要なら
+`globals.css` に補助クラスを追加して見た目を揃える（1箇所で管理）。
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| [e.g., 4th project] | [current need] | [why 3 projects insufficient] |
+| [e.g., Repository pattern] | [specific problem] | [why direct DB access insufficient] |

--- a/specs/023-activities-link-buttons/quickstart.md
+++ b/specs/023-activities-link-buttons/quickstart.md
@@ -1,0 +1,29 @@
+# Quickstart: Activities link button sizing unification
+
+**Feature**: `specs/023-activities-link-buttons/spec.md`  
+**Date**: 2025-12-28
+
+## Run locally
+
+```bash
+cd /Users/takeshiwatanabe/EureWorks/private/git/portfolio
+pnpm dev
+```
+
+## Verify
+
+1. Open `http://localhost:3000`
+2. Scroll to **Activities**
+3. Confirm link buttons:
+   - Have a consistent height and text size
+   - Do not wrap to multiple lines even when labels are long
+4. Tab through buttons and confirm focus remains visible.
+
+## Quality gates
+
+```bash
+pnpm lint
+pnpm build
+```
+
+

--- a/specs/023-activities-link-buttons/research.md
+++ b/specs/023-activities-link-buttons/research.md
@@ -1,0 +1,26 @@
+# Research: Activities link button sizing unification
+
+**Feature**: `specs/023-activities-link-buttons/spec.md`  
+**Date**: 2025-12-28
+
+## Decisions
+
+### Decision: Keep NES.css button base, add minimal Tailwind utilities to normalize size
+
+- **Chosen**: Use `nes-btn` + `is-small` as the base, and add a small set of Tailwind utilities:
+  - `whitespace-nowrap` to prevent wrapping (stabilize height)
+  - `text-[0.7rem] leading-none` to normalize label sizing
+  - `shrink-0` to prevent flex squish
+- **Rationale**:
+  - No new dependencies
+  - Minimal diff scoped to Activities
+  - Keeps retro styling consistent with the rest of the site
+- **Alternatives considered**:
+  - Global CSS overrides for all `.nes-btn` (rejected: too broad/risky)
+  - Fixed-width buttons with truncation (rejected: may hide important label)
+
+## Notes
+
+If any label still wraps on narrow screens, prefer allowing horizontal scroll or reducing letter spacing rather than increasing button height.
+
+

--- a/specs/023-activities-link-buttons/spec.md
+++ b/specs/023-activities-link-buttons/spec.md
@@ -1,0 +1,112 @@
+# Feature Specification: Activities link button sizing unification
+
+**Feature Branch**: `023-activities-link-buttons`  
+**Created**: 2025-12-28  
+**Status**: Draft  
+**Input**: User description: "Activitiesのlinkボタンが大きさ違くてダサいので統一したい。"
+
+## User Scenarios & Testing *(mandatory)*
+
+<!--
+  IMPORTANT: User stories should be PRIORITIZED as user journeys ordered by importance.
+  Each user story/journey must be INDEPENDENTLY TESTABLE - meaning if you implement just ONE of them,
+  you should still have a viable MVP (Minimum Viable Product) that delivers value.
+  
+  Assign priorities (P1, P2, P3, etc.) to each story, where P1 is the most critical.
+  Think of each story as a standalone slice of functionality that can be:
+  - Developed independently
+  - Tested independently
+  - Deployed independently
+  - Demonstrated to users independently
+-->
+
+### User Story 1 - Consistent Activities link buttons (Priority: P1)
+
+閲覧者として、Activities の各アイテムに付くリンクボタンが同じ見た目（サイズ/高さ/余白）で揃っていてほしい。
+
+**Why this priority**: 視覚的なノイズが減り、一覧のリズムが良くなる（“ダサい”を潰す）。
+
+**Independent Test**: `pnpm dev` → Activities の複数リンクボタンが、ラベル長に関わらず同じ高さで表示される（折返しで高さが変わらない）。
+
+**Acceptance Scenarios**:
+
+1. **Given** Activities に複数のリンク付きアイテムがある、**When** 画面表示する、**Then** ボタンの高さ/文字サイズ/余白が統一される
+2. **Given** リンクラベルが長い、**When** 表示する、**Then** ボタンが折り返さず（高さが増えず）見た目が崩れない
+
+---
+
+### User Story 2 - A11y + focus consistency (Priority: P2)
+
+閲覧者として、キーボード操作時のフォーカス状態が他のボタンと同様に分かりやすいままであってほしい。
+
+**Why this priority**: “揃える”変更でアクセシビリティや視認性が悪化しないようにする。
+
+**Independent Test**: Activities のリンクボタンに Tab で移動しても視認性が保たれ、クリック領域が小さくなりすぎない。
+
+**Acceptance Scenarios**:
+
+1. **Given** キーボード操作、**When** Tab でリンクボタンにフォーカス、**Then** フォーカスが視認できる
+
+---
+
+### User Story 3 - Maintainability (Priority: P3)
+
+開発者として、Activities のリンクボタンの見た目を一箇所の定義で管理できるようにしたい。
+
+**Why this priority**: 今後ラベルや表示箇所が増えても “不揃い” が再発しにくい。
+
+**Independent Test**: 変更が `src/components/sections/ActivitiesSection.tsx`（必要なら `src/app/globals.css`）に閉じる。
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+[Add more user stories as needed, each with an assigned priority]
+
+### Edge Cases
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right edge cases.
+-->
+
+- リンクラベルが長い（折返しで高さが変わる問題の再発）
+- リンクがないアイテム（ボタンが存在しない）
+- モバイル幅での表示（ボタンがはみ出す/潰れる）
+
+## Requirements *(mandatory)*
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right functional requirements.
+-->
+
+### Functional Requirements
+
+- **FR-001**: システム MUST Activities のリンクボタンの高さ/文字サイズ/余白を統一する（`src/components/sections/ActivitiesSection.tsx`）
+- **FR-002**: システム MUST 長いラベルでもボタンが折り返して高さが増えないようにする（例: `whitespace-nowrap`）
+- **FR-003**: システム MUST キーボードフォーカスの視認性を維持する
+- **FR-004**: システム SHOULD ボタンスタイルの定義を一箇所に集約する（定数 or CSSクラス）
+
+*Example of marking unclear requirements:*
+
+- **FR-006**: System MUST authenticate users via [NEEDS CLARIFICATION: auth method not specified - email/password, SSO, OAuth?]
+- **FR-007**: System MUST retain user data for [NEEDS CLARIFICATION: retention period not specified]
+
+### Key Entities *(include if feature involves data)*
+
+- N/A (UI-only change)
+
+## Success Criteria *(mandatory)*
+
+<!--
+  ACTION REQUIRED: Define measurable success criteria.
+  These must be technology-agnostic and measurable.
+-->
+
+### Measurable Outcomes
+
+- **SC-001**: Activities のリンクボタンが統一された見た目になっている
+- **SC-002**: `pnpm lint` と `pnpm build` が通る

--- a/specs/023-activities-link-buttons/tasks.md
+++ b/specs/023-activities-link-buttons/tasks.md
@@ -1,0 +1,83 @@
+---
+description: "Tasks for 023-activities-link-buttons"
+---
+
+# Tasks: Activities link button sizing unification
+
+**Input**: Design documents from `/Users/takeshiwatanabe/EureWorks/private/git/portfolio/specs/023-activities-link-buttons/`  
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `quickstart.md`
+
+**Tests**: No automated tests requested; verify via `pnpm dev` + `pnpm lint` + `pnpm build`.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm baseline build health before UI tweaks.
+
+- [X] T001 Confirm baseline quality gates: run `pnpm lint` and `pnpm build` in `/Users/takeshiwatanabe/EureWorks/private/git/portfolio/`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Identify the current source of inconsistent sizing and choose the single source of truth for the className.
+
+- [X] T002 Inspect current Activities link button rendering in `src/components/sections/ActivitiesSection.tsx` and list all button variants found
+- [X] T003 Define a single reusable className constant (e.g., `ACTIVITIES_LINK_BTN_CLASS`) in `src/components/sections/ActivitiesSection.tsx`
+
+**Checkpoint**: There is exactly one place defining the Activities link button style.
+
+---
+
+## Phase 3: User Story 1 - Consistent Activities link buttons (Priority: P1) 🎯 MVP
+
+**Goal**: Make Activities link buttons consistent in height/text/padding regardless of label length.
+
+**Independent Test**: `pnpm dev` → Activities の複数リンクボタンが同じ高さで表示され、長いラベルでも折り返さない。
+
+- [X] T004 [US1] Update Activities link `<a>` button className in `src/components/sections/ActivitiesSection.tsx` to use the shared constant
+- [X] T005 [US1] Add minimal utilities to prevent wrap and normalize size in `src/components/sections/ActivitiesSection.tsx` (per research): `whitespace-nowrap`, `text-[0.7rem]`, `leading-none`, `shrink-0`
+- [X] T006 [US1] Ensure button remains aligned and does not distort layout on mobile (adjust container or add `max-w`/`truncate` on label only if necessary) in `src/components/sections/ActivitiesSection.tsx`
+
+---
+
+## Phase 4: User Story 2 - A11y + focus consistency (Priority: P2)
+
+**Goal**: Keep keyboard focus visibility and avoid reducing clickable target too much.
+
+**Independent Test**: Tab で Activities のリンクボタンを辿ってもフォーカスが見える（NES.cssの見た目を維持）。
+
+- [X] T007 [US2] Verify focus visibility for Activities link buttons; if needed, add `focus-visible:*` utilities in `src/components/sections/ActivitiesSection.tsx`
+
+---
+
+## Phase 5: User Story 3 - Maintainability (Priority: P3)
+
+**Goal**: Prevent re-introducing inconsistent button sizing in the future.
+
+**Independent Test**: The button style is defined once, easy to adjust, and documented in-code.
+
+- [X] T008 [US3] Add a short comment above the shared className constant in `src/components/sections/ActivitiesSection.tsx` describing the invariants (no wrap, consistent height)
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Quality gates + quickstart validation. Docs sync is not required (no top-level UX change).
+
+- [X] T009 Run `pnpm lint` and fix any issues
+- [X] T010 Run `pnpm build` and fix any issues
+- [X] T011 Validate `specs/023-activities-link-buttons/quickstart.md` steps end-to-end
+
+---
+
+## Dependencies & Execution Order
+
+- Setup (T001) → Foundational (T002–T003) → US1 (T004–T006) → US2 (T007) → US3 (T008) → Polish (T009–T011)
+
+---
+
+## Parallel Example: (limited)
+
+This feature is mostly single-file (`ActivitiesSection.tsx`) work, so parallelism is limited.
+
+

--- a/src/components/sections/ActivitiesSection.tsx
+++ b/src/components/sections/ActivitiesSection.tsx
@@ -5,6 +5,12 @@ function isExternalHttpHref(href: string) {
   return href.startsWith("http://") || href.startsWith("https://");
 }
 
+// Activities link button invariant:
+// - consistent height/typography across items
+// - never wrap (wrapping increases height and looks uneven)
+const ACTIVITIES_LINK_BTN_CLASS =
+  "nes-btn is-small shrink-0 whitespace-nowrap text-[0.7rem] leading-none focus:outline-none focus-visible:ring-4 focus-visible:ring-fami-gold focus-visible:ring-offset-4 focus-visible:ring-offset-[#111]";
+
 export async function ActivitiesSection() {
   const { activities } = await getPortfolio();
 
@@ -56,7 +62,7 @@ export async function ActivitiesSection() {
 
                       {item.link ? (
                         <a
-                          className="nes-btn is-small shrink-0"
+                          className={ACTIVITIES_LINK_BTN_CLASS}
                           href={item.link.href}
                           target={isExternalHttpHref(item.link.href) ? "_blank" : undefined}
                           rel={isExternalHttpHref(item.link.href) ? "noreferrer" : undefined}


### PR DESCRIPTION
### Summary
- Unify Activities item link button sizing/typography using a shared class constant
- Prevent label wrap so button height stays consistent
- Keep focus visibility (adds focus-visible ring)

### Verification
- pnpm lint
- pnpm build
