### PR TITLE
UI: enlarge year/period badges (non-Skills)

### DIFF
--- a/specs/024-section-typography/contracts/README.md
+++ b/specs/024-section-typography/contracts/README.md
@@ -1,0 +1,5 @@
+# Contracts: N/A
+
+This feature is purely presentational (UI-only). No external APIs/contracts.
+
+

--- a/specs/024-section-typography/data-model.md
+++ b/specs/024-section-typography/data-model.md
@@ -1,0 +1,8 @@
+# Data Model: Section typography size upgrade
+
+**Feature**: `specs/024-section-typography/spec.md`  
+**Date**: 2025-12-28
+
+This feature is UI-only. No data model changes.
+
+

--- a/specs/024-section-typography/plan.md
+++ b/specs/024-section-typography/plan.md
@@ -1,0 +1,83 @@
+# Implementation Plan: Section typography size upgrade
+
+**Branch**: `024-section-typography` | **Date**: 2025-12-28 | **Spec**: `specs/024-section-typography/spec.md`
+**Input**: Feature specification from `specs/024-section-typography/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/commands/plan.md` for the execution workflow.
+
+## Summary
+
+SectionContent（各セクション本文）の文字サイズが小さすぎる問題を解消する。
+各セクションの本文系 `text-sm/text-xs` を見直し、`text-base` へ引き上げる。
+再発防止として “本文トークン” を共通クラス/定数として集約する（CSS or TSX）。
+
+## Technical Context
+
+<!--
+  ACTION REQUIRED: Replace the content in this section with the technical details
+  for the project. The structure here is presented in advisory capacity to guide
+  the iteration process.
+-->
+
+**Language/Version**: TypeScript 5.x (Next.js App Router)  
+**Primary Dependencies**: Next.js 16, React 19, Tailwind CSS 3, NES.css  
+**Storage**: N/A  
+**Testing**: N/A (no automated tests; rely on `pnpm lint` + `pnpm build`)  
+**Target Platform**: Vercel  
+**Project Type**: Web application (Next.js App Router under `src/`)  
+**Performance Goals**: No new deps; CSS-first; no layout shift/regressions  
+**Constraints**: Retro aesthetic + modern usability; keep hierarchy; avoid dense sections becoming noisy  
+**Scale/Scope**: Section body text across all sections
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Use `.specify/memory/constitution.md` as the source of truth. This repo’s default
+gates (adapt per feature) are:
+
+- Principle compliance: changes support “Personality-First Storytelling” and do not
+  dilute the retro aesthetic + usability balance.
+- Quality gates: `pnpm lint` and `pnpm build` pass.
+- Docs sync: if dependencies/scripts/runtime/deploy/top-level UX change, update
+  `README.md`, `AGENTS.md`, and `CLAUDE.md` together.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/[###-feature]/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+<!--
+  ACTION REQUIRED: Replace the placeholder tree below with the concrete layout
+  for this feature. Delete unused options and expand the chosen structure with
+  real paths (e.g., apps/admin, packages/something). The delivered plan must
+  not include Option labels.
+-->
+
+```text
+src/
+├── app/globals.css                 # optional typography utility classes
+└── components/sections/*           # update body text classes
+```
+
+**Structure Decision**: 原則は “本文トークン（CSSクラス）” を `globals.css` に置き、
+各セクションは本文要素にそのクラスを付与して統一する（差分は最小）。
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| [e.g., 4th project] | [current need] | [why 3 projects insufficient] |
+| [e.g., Repository pattern] | [specific problem] | [why direct DB access insufficient] |

--- a/specs/024-section-typography/quickstart.md
+++ b/specs/024-section-typography/quickstart.md
@@ -1,0 +1,30 @@
+# Quickstart: Section typography size upgrade
+
+**Feature**: `specs/024-section-typography/spec.md`  
+**Date**: 2025-12-28
+
+## Run locally
+
+```bash
+cd /Users/takeshiwatanabe/EureWorks/private/git/portfolio
+pnpm dev
+```
+
+## Verify
+
+1. Open `http://localhost:3000`
+2. Check section body copy (Profile/Work/Writing/Activities/Skills/Contact):
+   - Paragraph text is visibly larger than before (aim: `text-base` default)
+   - Dense UI (badges/buttons) remains readable and not oversized
+3. Check mobile width:
+   - Lines wrap naturally (no overflow)
+   - No layout shift from typography changes
+
+## Quality gates
+
+```bash
+pnpm lint
+pnpm build
+```
+
+

--- a/specs/024-section-typography/research.md
+++ b/specs/024-section-typography/research.md
@@ -1,0 +1,26 @@
+# Research: Section typography size upgrade
+
+**Feature**: `specs/024-section-typography/spec.md`  
+**Date**: 2025-12-28
+
+## Decisions
+
+### Decision: Promote section body text to `text-base` by default
+
+- **Chosen**: Use `text-base` as the default for section body paragraphs and descriptive copy.
+- **Rationale**:
+  - Current `text-sm` (and scattered `text-xs`) reads too small, especially on mobile.
+  - Aligns with constitution “Modern Usability” without breaking the retro palette.
+- **Alternatives considered**:
+  - Increasing global `html/body` font-size (rejected: too broad; affects menu/buttons/badges).
+
+### Decision: Use a shared typography token for “section body”
+
+- **Chosen**: Add a small shared class (e.g. `.section-body`) in `src/app/globals.css` and apply it across sections.
+- **Rationale**: Avoids drift; easy future tuning from one place.
+
+## Open Questions
+
+- Whether dense parts (Skills progress labels, badges) should remain small (`text-xs`) while descriptions become `text-base`.
+
+

--- a/specs/024-section-typography/spec.md
+++ b/specs/024-section-typography/spec.md
@@ -1,0 +1,107 @@
+# Feature Specification: Section typography size upgrade
+
+**Feature Branch**: `024-section-typography`  
+**Created**: 2025-12-28  
+**Status**: Draft  
+**Input**: User description: "各SectionContentの文字サイズが小さすぎるので上げたい。"
+
+## User Scenarios & Testing *(mandatory)*
+
+<!--
+  IMPORTANT: User stories should be PRIORITIZED as user journeys ordered by importance.
+  Each user story/journey must be INDEPENDENTLY TESTABLE - meaning if you implement just ONE of them,
+  you should still have a viable MVP (Minimum Viable Product) that delivers value.
+  
+  Assign priorities (P1, P2, P3, etc.) to each story, where P1 is the most critical.
+  Think of each story as a standalone slice of functionality that can be:
+  - Developed independently
+  - Tested independently
+  - Deployed independently
+  - Demonstrated to users independently
+-->
+
+### User Story 1 - Readable section body text (Priority: P1)
+
+訪問者として、各セクション本文（説明文・段落・補足）が小さすぎず、自然に読める文字サイズになっていてほしい。
+
+**Why this priority**: 読めないと内容が伝わらない。最重要の品質。
+
+**Independent Test**: `pnpm dev` → Profile/Work/Writing/Activities/Skills/Contact の本文が “text-base相当以上” になり、モバイルでも読みやすい。
+
+**Acceptance Scenarios**:
+
+1. **Given** トップページ、**When** 各セクション本文を見る、**Then** 小さすぎないサイズで表示される
+2. **Given** モバイル幅、**When** 表示する、**Then** 行間/折返しが崩れず読みやすい
+
+---
+
+### User Story 2 - Keep hierarchy and retro mood (Priority: P2)
+
+訪問者として、文字サイズを上げても見出し階層が崩れず、レトロな雰囲気が保たれていてほしい。
+
+**Why this priority**: 文字が大きいだけで “野暮ったい” になるのを防ぐ。
+
+**Independent Test**: 見出し（H2/H3）と本文のコントラストが維持され、セクション間の情報設計が分かりやすい。
+
+**Acceptance Scenarios**:
+
+1. **Given** 各セクション、**When** 見出し/本文を見る、**Then** 見出しが相対的に目立ち続ける
+
+---
+
+### User Story 3 - Maintainable typography tokens (Priority: P3)
+
+開発者として、本文の文字サイズ/行間を“方針として一箇所”で管理できるようにしたい（増改築でブレない）。
+
+**Why this priority**: 今後のUI調整でも再発しにくい。
+
+**Independent Test**: 主要セクションは `section-body` のような共通クラス/定数で統一できる。
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+[Add more user stories as needed, each with an assigned priority]
+
+### Edge Cases
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right edge cases.
+-->
+
+- モバイルでの折り返し/はみ出し（ボタン・バッジ・長文）
+- 文字サイズ上げにより “情報量が多く見える” ので、余白/行間が必要になる
+- Activities/Skills のような密度が高い箇所が破綻しない
+
+## Requirements *(mandatory)*
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right functional requirements.
+-->
+
+### Functional Requirements
+
+- **FR-001**: システム MUST 各セクション本文（段落/説明文）のデフォルト文字サイズを上げる
+- **FR-002**: システム SHOULD `text-xs` 相当の本文を減らし、必要箇所のみ小さめ表示に限定する
+- **FR-003**: システム MUST 見出し階層（H2/H3）と本文の視覚的コントラストを維持する
+- **FR-004**: システム SHOULD 本文のタイポグラフィ（サイズ/行間）を共通トークンとして一箇所に集約する（CSSクラス or 定数）
+
+### Key Entities *(include if feature involves data)*
+
+- N/A (UI-only)
+
+## Success Criteria *(mandatory)*
+
+<!--
+  ACTION REQUIRED: Define measurable success criteria.
+  These must be technology-agnostic and measurable.
+-->
+
+### Measurable Outcomes
+
+- **SC-001**: 主要セクション本文が読みやすい文字サイズになっている（目視で “小さすぎない”）
+- **SC-002**: `pnpm lint` と `pnpm build` が通る

--- a/specs/024-section-typography/tasks.md
+++ b/specs/024-section-typography/tasks.md
@@ -1,0 +1,93 @@
+---
+description: "Tasks for 024-section-typography"
+---
+
+# Tasks: Section typography size upgrade
+
+**Input**: Design documents from `/Users/takeshiwatanabe/EureWorks/private/git/portfolio/specs/024-section-typography/`  
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `quickstart.md`
+
+**Tests**: No automated tests requested; verify via `pnpm dev` + `pnpm lint` + `pnpm build`.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Baseline quality gates before sweeping typography changes.
+
+- [X] T001 Confirm baseline quality gates: run `pnpm lint` and `pnpm build` in `/Users/takeshiwatanabe/EureWorks/private/git/portfolio/`
+- [X] T002 [P] Inventory current body text sizing usage (`text-xs/text-sm/text-base`) in `src/components/sections/*` and list candidates to promote to `text-base`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Introduce a shared “section body” typography token to avoid drift.
+
+- [X] T003 Add a shared `.section-body` class in `src/app/globals.css` (e.g., `text-base leading-relaxed [font-family:var(--font-noto)]`)
+- [X] T004 Define a companion `.section-body-muted` (optional) for secondary descriptions (e.g., `text-sm text-fami-ivory/90`) in `src/app/globals.css`
+
+**Checkpoint**: There is a single, named token for default section body typography.
+
+---
+
+## Phase 3: User Story 1 - Readable section body text (Priority: P1) 🎯 MVP
+
+**Goal**: Promote section paragraphs/descriptions to a readable default size.
+
+**Independent Test**: `pnpm dev` → Profile/Work/Writing/Activities/Skills/Contact 本文が読みやすいサイズ（基本 `text-base`）になっている。
+
+- [X] T005 [P] [US1] Apply `.section-body` to Profile body in `src/components/sections/ProfileSection.tsx` and remove redundant `text-sm` if present
+- [X] T006 [P] [US1] Apply `.section-body` to Work descriptive copy in `src/components/sections/WorkSection.tsx` (section intro + entry summary) while keeping badges/buttons unchanged
+- [X] T007 [P] [US1] Apply `.section-body` to Writing descriptive copy in `src/components/sections/WritingSection.tsx`
+- [X] T008 [P] [US1] Apply `.section-body` to Activities intro + item context paragraphs in `src/components/sections/ActivitiesSection.tsx` (keep year badge and button sizing as-is)
+- [X] T009 [P] [US1] Apply `.section-body` to Contact blurb in `src/components/sections/ContactSection.tsx`
+
+---
+
+## Phase 4: User Story 2 - Keep hierarchy and retro mood (Priority: P2)
+
+**Goal**: Ensure typography changes don’t flatten hierarchy or break the retro look.
+
+**Independent Test**: H2/H3 headings remain clearly dominant; dense UI remains compact and readable.
+
+- [X] T010 [US2] Review Skills section typography in `src/components/sections/SkillsSection.tsx`; keep dense labels small where appropriate, but promote any true paragraph/descriptive copy to `.section-body`
+- [X] T011 [US2] Verify no accidental “global” font bump: ensure `html/body` font-size is unchanged in `src/app/globals.css`
+
+---
+
+## Phase 5: User Story 3 - Maintainable typography tokens (Priority: P3)
+
+**Goal**: Make future typography adjustments easy and consistent.
+
+**Independent Test**: Most section paragraphs use `.section-body` or `.section-body-muted` rather than ad-hoc `text-sm/text-xs`.
+
+- [X] T012 [US3] Replace repeated `[font-family:var(--font-noto)]` + size utilities on paragraphs with `.section-body`/`.section-body-muted` where applicable across `src/components/sections/*`
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Validate build integrity and quickstart checks. Docs sync is not required unless top-level UX guidance changes.
+
+- [X] T013 Run `pnpm lint` and fix any issues introduced by refactors
+- [X] T014 Run `pnpm build` and fix any issues introduced by refactors
+- [X] T015 Validate `specs/024-section-typography/quickstart.md` steps end-to-end
+
+---
+
+## Dependencies & Execution Order
+
+- Setup (T001–T002) → Foundational (T003–T004) → US1 (T005–T009) → US2 (T010–T011) → US3 (T012) → Polish (T013–T015)
+
+---
+
+## Parallel Example: User Story 1
+
+```text
+Task: T005 [P] [US1] ProfileSection typography
+Task: T006 [P] [US1] WorkSection typography
+Task: T007 [P] [US1] WritingSection typography
+Task: T008 [P] [US1] ActivitiesSection typography
+Task: T009 [P] [US1] ContactSection typography
+```
+
+

--- a/specs/025-year-badges/checklists/requirements.md
+++ b/specs/025-year-badges/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Year badge readability upgrade (non-Skills)
+      
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2025-12-28  
+**Feature**: `specs/025-year-badges/spec.md`
+      
+## Content Quality
+      
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+      
+## Requirement Completeness
+      
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+      
+## Feature Readiness
+      
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+      
+## Notes
+      
+- None
+

--- a/specs/025-year-badges/contracts/README.md
+++ b/specs/025-year-badges/contracts/README.md
@@ -1,0 +1,5 @@
+# Contracts: N/A
+
+This feature is purely presentational (UI-only). No external APIs/contracts.
+
+

--- a/specs/025-year-badges/data-model.md
+++ b/specs/025-year-badges/data-model.md
@@ -1,0 +1,8 @@
+# Data Model: Year badge readability upgrade (non-Skills)
+
+**Feature**: `specs/025-year-badges/spec.md`  
+**Date**: 2025-12-28
+
+This feature is UI-only. No data model changes.
+
+

--- a/specs/025-year-badges/plan.md
+++ b/specs/025-year-badges/plan.md
@@ -1,0 +1,84 @@
+# Implementation Plan: Year badge readability upgrade (non-Skills)
+
+**Branch**: `025-year-badges` | **Date**: 2025-12-28 | **Spec**: `specs/025-year-badges/spec.md`
+**Input**: Feature specification from `specs/025-year-badges/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/commands/plan.md` for the execution workflow.
+
+## Summary
+
+Skills以外の year/period バッジ（Workのperiod、Activitiesのyear）の文字が小さすぎて読めない問題を解消する。
+共通CSSトークン（例: `.year-badge`）にサイズ方針を集約し、Work/Activitiesへ適用する。Skillsは対象外。
+
+## Technical Context
+
+<!--
+  ACTION REQUIRED: Replace the content in this section with the technical details
+  for the project. The structure here is presented in advisory capacity to guide
+  the iteration process.
+-->
+
+**Language/Version**: TypeScript 5.x (Next.js App Router)  
+**Primary Dependencies**: Next.js 16, React 19, Tailwind CSS 3, NES.css  
+**Storage**: N/A  
+**Testing**: N/A (no automated tests; rely on `pnpm lint` + `pnpm build`)  
+**Target Platform**: Vercel  
+**Project Type**: Web application (Next.js App Router under `src/`)  
+**Performance Goals**: No new deps; CSS-first; avoid layout shift  
+**Constraints**: Keep retro look; improve readability; Skills is out-of-scope  
+**Scale/Scope**: Work + Activities year/period badges only
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Use `.specify/memory/constitution.md` as the source of truth. This repo’s default
+gates (adapt per feature) are:
+
+- Principle compliance: changes support “Personality-First Storytelling” and do not
+  dilute the retro aesthetic + usability balance.
+- Quality gates: `pnpm lint` and `pnpm build` pass.
+- Docs sync: if dependencies/scripts/runtime/deploy/top-level UX change, update
+  `README.md`, `AGENTS.md`, and `CLAUDE.md` together.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/[###-feature]/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+<!--
+  ACTION REQUIRED: Replace the placeholder tree below with the concrete layout
+  for this feature. Delete unused options and expand the chosen structure with
+  real paths (e.g., apps/admin, packages/something). The delivered plan must
+  not include Option labels.
+-->
+
+```text
+src/
+├── app/globals.css
+└── components/sections/
+   ├── WorkSection.tsx
+   └── ActivitiesSection.tsx
+```
+
+**Structure Decision**: `.year-badge` を `globals.css` に追加し、Work/Activitiesの年表示に付与する。
+Skillsは変更しない。
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| [e.g., 4th project] | [current need] | [why 3 projects insufficient] |
+| [e.g., Repository pattern] | [specific problem] | [why direct DB access insufficient] |

--- a/specs/025-year-badges/quickstart.md
+++ b/specs/025-year-badges/quickstart.md
@@ -1,0 +1,32 @@
+# Quickstart: Year badge readability upgrade (non-Skills)
+
+**Feature**: `specs/025-year-badges/spec.md`  
+**Date**: 2025-12-28
+
+## Run locally
+
+```bash
+cd /Users/takeshiwatanabe/EureWorks/private/git/portfolio
+pnpm dev
+```
+
+## Verify
+
+1. Open `http://localhost:3000`
+2. Check **Work**:
+   - The period badge (e.g. `2019–2025`) is readable at a glance
+3. Check **Activities**:
+   - The year badge (e.g. `2024`) is readable at a glance
+4. Confirm **Skills** is unchanged:
+   - Skills year/labels remain as-is
+5. Check mobile width:
+   - Badges do not cause awkward wrapping or collapsed layouts
+
+## Quality gates
+
+```bash
+pnpm lint
+pnpm build
+```
+
+

--- a/specs/025-year-badges/research.md
+++ b/specs/025-year-badges/research.md
@@ -1,0 +1,29 @@
+# Research: Year badge readability upgrade (non-Skills)
+
+**Feature**: `specs/025-year-badges/spec.md`  
+**Date**: 2025-12-28
+
+## Decisions
+
+### Decision: Introduce a shared `.year-badge` token and apply to Work + Activities
+
+- **Chosen**: Add a small CSS utility class (e.g., `.year-badge`) in `src/app/globals.css` and apply it to:
+  - Work: period badge
+  - Activities: year badge
+- **Rationale**:
+  - Removes scattered `text-[0.6rem]` tweaks and prevents future drift.
+  - Keeps the retro `nes-badge` look; only improves legibility.
+- **Alternatives considered**:
+  - Increase global badge font-size (rejected: affects all badges, including Skills and tech tags).
+
+### Decision: Target sizing
+
+- **Chosen**: Increase from ~`0.6rem` to ~`0.75rem` (or equivalent) for year/period only.
+- **Rationale**: Readable on mobile without making badge rows too tall.
+
+## Guardrails
+
+- Skills is explicitly out-of-scope; do not change Skills year sizing.
+- Prefer minimal layout impact: avoid changing badge padding/margins unless necessary.
+
+

--- a/specs/025-year-badges/spec.md
+++ b/specs/025-year-badges/spec.md
@@ -1,0 +1,109 @@
+# Feature Specification: Year badge readability upgrade (non-Skills)
+
+**Feature Branch**: `025-year-badges`  
+**Created**: 2025-12-28  
+**Status**: Draft  
+**Input**: User description: "skills以外のsectionのyearが小さすぎて見えないので大きくして統一したい"
+
+## User Scenarios & Testing *(mandatory)*
+
+<!--
+  IMPORTANT: User stories should be PRIORITIZED as user journeys ordered by importance.
+  Each user story/journey must be INDEPENDENTLY TESTABLE - meaning if you implement just ONE of them,
+  you should still have a viable MVP (Minimum Viable Product) that delivers value.
+  
+  Assign priorities (P1, P2, P3, etc.) to each story, where P1 is the most critical.
+  Think of each story as a standalone slice of functionality that can be:
+  - Developed independently
+  - Tested independently
+  - Deployed independently
+  - Demonstrated to users independently
+-->
+
+### User Story 1 - Readable “year” badges (Priority: P1)
+
+閲覧者として、Skills以外のセクションで表示される “year/period” バッジが小さすぎず、ひと目で読める大きさになっていてほしい。
+
+**Why this priority**: 年（時系列）は一覧のキー情報なので、読めないと価値が落ちる。
+
+**Independent Test**: `pnpm dev` → Workのperiod、ActivitiesのyearバッジがSkillsと同等の視認性で表示される。
+
+**Acceptance Scenarios**:
+
+1. **Given** トップページ、**When** Workのperiodを見る、**Then** 小さすぎず読める
+2. **Given** トップページ、**When** Activitiesのyearを見る、**Then** 小さすぎず読める
+
+---
+
+### User Story 2 - Keep layout stable (Priority: P2)
+
+閲覧者として、yearバッジを大きくしてもレイアウトが崩れず、モバイルでも詰まりすぎない見た目であってほしい。
+
+**Why this priority**: 文字だけ大きくすると詰まり・折返し・ズレが起きやすい。
+
+**Independent Test**: モバイル幅でもバッジが潰れず、行の高さが極端に増えない。
+
+**Acceptance Scenarios**:
+
+1. **Given** モバイル幅、**When** 表示する、**Then** year/periodバッジで行が破綻しない
+
+---
+
+### User Story 3 - Single source of truth (Priority: P3)
+
+開発者として、year/periodバッジのサイズ方針を一箇所に集約し、今後の追加で不揃いが再発しないようにしたい。
+
+**Why this priority**: UIの一貫性を保つため。
+
+**Independent Test**: 共通クラス（例: `.year-badge`）で管理され、個別の `text-[0.6rem]` が散らばらない。
+
+**Acceptance Scenarios**:
+
+1. **Given** year/periodバッジが複数箇所にある、**When** 実装を見る、**Then** 共通クラスで統一されている
+
+---
+
+[Add more user stories as needed, each with an assigned priority]
+
+### Edge Cases
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right edge cases.
+-->
+
+- 年/期間文字列が長い（例: “2019–2025”）場合でも見切れない
+- モバイル幅で詰まる場合の折返し/省略の扱い
+- Skillsは対象外（既存の見た目を維持）
+
+## Requirements *(mandatory)*
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right functional requirements.
+-->
+
+### Functional Requirements
+
+- **FR-001**: システム MUST Skills以外の year/period バッジの文字サイズを引き上げる
+- **FR-002**: システム MUST Workのperiodバッジ（`WorkSection`）と Activitiesのyearバッジ（`ActivitiesSection`）の見た目を統一する
+- **FR-003**: システム MUST モバイルでもレイアウトが崩れないようにする（折返し・詰まり対策）
+- **FR-004**: システム SHOULD year/period バッジのスタイルを一箇所に集約する（共通クラス）
+- **FR-005**: システム MUST Skillsセクションのyear表示は変更しない（対象外）
+
+### Key Entities *(include if feature involves data)*
+
+- N/A (UI-only)
+
+## Success Criteria *(mandatory)*
+
+<!--
+  ACTION REQUIRED: Define measurable success criteria.
+  These must be technology-agnostic and measurable.
+-->
+
+### Measurable Outcomes
+
+- **SC-001**: Work/Activitiesのyear/periodバッジがひと目で読めるサイズになっている
+- **SC-002**: モバイル幅でレイアウトが破綻しない
+- **SC-003**: `pnpm lint` と `pnpm build` が通る

--- a/specs/025-year-badges/tasks.md
+++ b/specs/025-year-badges/tasks.md
@@ -1,0 +1,78 @@
+---
+description: "Tasks for 025-year-badges"
+---
+
+# Tasks: Year badge readability upgrade (non-Skills)
+
+**Input**: Design documents from `/Users/takeshiwatanabe/EureWorks/private/git/portfolio/specs/025-year-badges/`  
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `quickstart.md`
+
+**Tests**: No automated tests requested; verify via `pnpm dev` + `pnpm lint` + `pnpm build`.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm baseline build health before UI adjustments.
+
+- [X] T001 Confirm baseline quality gates: run `pnpm lint` and `pnpm build` in `/Users/takeshiwatanabe/EureWorks/private/git/portfolio/`
+- [X] T002 [P] Inventory current year/period badge sizing in `src/components/sections/WorkSection.tsx` and `src/components/sections/ActivitiesSection.tsx` (find `text-[0.6rem]`, `text-xs`, etc.)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Introduce a single source of truth for year/period badge typography.
+
+- [X] T003 Add `.year-badge` CSS token in `src/app/globals.css` (target: ~`0.75rem` text size; keep NES badge look)
+- [X] T004 Ensure `.year-badge` does not affect Skills (do not apply it in `src/components/sections/SkillsSection.tsx`)
+
+**Checkpoint**: A single `.year-badge` exists and is only used by non-Skills year/period badges.
+
+---
+
+## Phase 3: User Story 1 - Readable “year” badges (Priority: P1) 🎯 MVP
+
+**Goal**: Make Work/Activities year/period badges readable at a glance.
+
+**Independent Test**: `pnpm dev` → Workのperiod、ActivitiesのyearがSkillsと同等に読めるサイズ。
+
+- [X] T005 [US1] Apply `.year-badge` to Work period badge in `src/components/sections/WorkSection.tsx` (replace tiny `text-[0.6rem]` styling)
+- [X] T006 [US1] Apply `.year-badge` to Activities year badge in `src/components/sections/ActivitiesSection.tsx` (replace tiny `text-[0.6rem]` styling)
+
+---
+
+## Phase 4: User Story 2 - Keep layout stable (Priority: P2)
+
+**Goal**: Increase readability without breaking layout on mobile.
+
+**Independent Test**: Mobile widthでバッジが潰れず、行が不自然に伸びない。
+
+- [X] T007 [US2] Verify long strings like `2019–2025` don’t clip; if needed, adjust container layout in `src/components/sections/WorkSection.tsx` (avoid reducing font size)
+- [X] T008 [US2] Verify Activities rows remain aligned; if needed, adjust flex/wrapping rules in `src/components/sections/ActivitiesSection.tsx`
+
+---
+
+## Phase 5: User Story 3 - Single source of truth (Priority: P3)
+
+**Goal**: Prevent future drift by removing ad-hoc year sizing tweaks.
+
+**Independent Test**: No more per-component hardcoded tiny year sizing for Work/Activities.
+
+- [X] T009 [US3] Remove remaining hardcoded year/period font sizes in `WorkSection.tsx` / `ActivitiesSection.tsx` now covered by `.year-badge`
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Quality gates + quickstart validation. Docs sync not required (UI polish only).
+
+- [X] T010 Run `pnpm lint` and fix any issues
+- [X] T011 Run `pnpm build` and fix any issues
+- [X] T012 Validate `specs/025-year-badges/quickstart.md` steps end-to-end
+
+---
+
+## Dependencies & Execution Order
+
+- Setup (T001–T002) → Foundational (T003–T004) → US1 (T005–T006) → US2 (T007–T008) → US3 (T009) → Polish (T010–T012)
+
+

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -80,3 +80,17 @@ body {
 }
 
 /* Guardrail: avoid expensive animation patterns (keep transforms/opacity only). */
+
+/* Typography tokens */
+.section-body {
+  font-size: 1rem; /* tailwind: text-base */
+  line-height: 1.75rem; /* tailwind: leading-relaxed */
+  font-family: var(--font-noto);
+}
+
+.section-body-muted {
+  font-size: 0.875rem; /* tailwind: text-sm */
+  line-height: 1.25rem;
+  font-family: var(--font-noto);
+  color: rgba(248, 241, 220, 0.9); /* close to text-fami-ivory/90 */
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -94,3 +94,9 @@ body {
   font-family: var(--font-noto);
   color: rgba(248, 241, 220, 0.9); /* close to text-fami-ivory/90 */
 }
+
+/* Badge tokens */
+.year-badge {
+  font-size: 0.75rem;
+  line-height: 1rem;
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -97,6 +97,6 @@ body {
 
 /* Badge tokens */
 .year-badge {
-  font-size: 0.75rem;
-  line-height: 1rem;
+  font-size: 1rem;
+  line-height: 1.25rem;
 }

--- a/src/components/sections/ActivitiesSection.tsx
+++ b/src/components/sections/ActivitiesSection.tsx
@@ -50,7 +50,7 @@ export async function ActivitiesSection() {
                     <div className="flex items-start justify-between gap-3">
                       <div className="min-w-0">
                         <div className="flex flex-wrap items-center gap-2">
-                          <span className="nes-badge is-warning text-[0.6rem]">
+                          <span className="nes-badge is-warning year-badge">
                             <span>{item.year}</span>
                           </span>
                           <span className="truncate">{item.title}</span>

--- a/src/components/sections/ActivitiesSection.tsx
+++ b/src/components/sections/ActivitiesSection.tsx
@@ -27,7 +27,7 @@ export async function ActivitiesSection() {
         <span>{activities.heading}</span>
       </h2>
 
-      <p className="mt-3 text-sm [font-family:var(--font-noto)]">
+      <p className="section-body-muted mt-3">
         登壇・執筆・コミュニティ活動・受賞/実績をまとめています。
       </p>
 
@@ -56,7 +56,7 @@ export async function ActivitiesSection() {
                           <span className="truncate">{item.title}</span>
                         </div>
                         {item.context ? (
-                          <p className="mt-1 text-xs text-fami-ivory/90">{item.context}</p>
+                          <p className="section-body-muted mt-1 text-fami-ivory/90">{item.context}</p>
                         ) : null}
                       </div>
 

--- a/src/components/sections/ContactSection.tsx
+++ b/src/components/sections/ContactSection.tsx
@@ -35,7 +35,7 @@ export async function ContactSection() {
         <PixelIcon src="/assets/pixel/icons/contact.svg" decorative size="md" />
         <span>{contact.heading}</span>
       </h2>
-      <p className="mt-3 whitespace-pre-line text-sm [font-family:var(--font-noto)]">
+      <p className="section-body mt-3 whitespace-pre-line">
         {contact.blurb}
       </p>
       <div className="mt-6 flex flex-wrap gap-3">

--- a/src/components/sections/ProfileSection.tsx
+++ b/src/components/sections/ProfileSection.tsx
@@ -15,7 +15,7 @@ export async function ProfileSection() {
         <PixelIcon src="/assets/pixel/icons/profile.svg" decorative size="md" />
         <span>{profile.heading}</span>
       </h2>
-      <p className="mt-3 text-sm [font-family:var(--font-noto)]">{profile.body}</p>
+      <p className="section-body mt-3">{profile.body}</p>
     </section>
   );
 }

--- a/src/components/sections/SkillsSection.tsx
+++ b/src/components/sections/SkillsSection.tsx
@@ -35,6 +35,9 @@ export async function SkillsSection() {
         <PixelIcon src="/assets/pixel/icons/skills.svg" decorative size="md" />
         <span>{skills.heading}</span>
       </h2>
+      <p className="section-body-muted mt-3">
+        スキルは “経験年数” を目安に、強みの分布が伝わるように整理しています。
+      </p>
       {categories ? (
         <div className="mt-4 space-y-6">
           {categories.map((cat) => (

--- a/src/components/sections/WorkSection.tsx
+++ b/src/components/sections/WorkSection.tsx
@@ -25,7 +25,7 @@ export async function WorkSection() {
         <span className="pixel-float text-xs uppercase tracking-[0.3em] text-fami-gold">WORK LOG</span>
       </header>
 
-      <p className="mt-3 text-sm [font-family:var(--font-noto)]">
+      <p className="section-body-muted mt-3">
         会社/組織ごとに1つの文章で概要をまとめ、配下に具体的な取り組み（Projects）を載せています。
       </p>
 
@@ -54,7 +54,7 @@ export async function WorkSection() {
               ) : null}
             </div>
 
-            <p className="mt-3 break-words whitespace-pre-line text-sm leading-relaxed text-fami-ivory/95">
+            <p className="section-body mt-3 break-words whitespace-pre-line text-fami-ivory/95">
               {entry.summary}
             </p>
 

--- a/src/components/sections/WorkSection.tsx
+++ b/src/components/sections/WorkSection.tsx
@@ -1,6 +1,6 @@
+import { PixelIcon } from "@/components/PixelIcon";
 import { getPortfolio } from "@/content/portfolio";
 import Image from "next/image";
-import { PixelIcon } from "@/components/PixelIcon";
 
 function isExternalHttpHref(href: string) {
   return href.startsWith("http://") || href.startsWith("https://");

--- a/src/components/sections/WorkSection.tsx
+++ b/src/components/sections/WorkSection.tsx
@@ -35,7 +35,7 @@ export async function WorkSection() {
             <div className="flex flex-wrap items-center justify-between gap-2">
               <div className="min-w-0">
                 <div className="flex flex-wrap items-center gap-2">
-                  <span className="nes-badge is-primary text-[0.6rem]">
+                  <span className="nes-badge is-primary year-badge">
                     <span>{entry.period}</span>
                   </span>
                   <h3 className="truncate text-sm text-fami-gold" style={{ fontFamily: "var(--font-press)" }}>
@@ -101,12 +101,12 @@ export async function WorkSection() {
                       </h4>
                       <div className="flex items-center gap-2">
                         {project.visibility === "private" ? (
-                          <span className="nes-badge is-error text-[0.6rem]">
+                          <span className="nes-badge is-error year-badge">
                             <span>PRIVATE</span>
                           </span>
                         ) : null}
                         {project.status ? (
-                          <span className="nes-badge is-primary text-[0.6rem]">
+                          <span className="nes-badge is-primary year-badge">
                             <span>{project.status}</span>
                           </span>
                         ) : null}

--- a/src/components/sections/WritingSection.tsx
+++ b/src/components/sections/WritingSection.tsx
@@ -20,7 +20,7 @@ export async function WritingSection() {
         <span>{writing.heading}</span>
       </h2>
 
-      <p className="mt-3 text-sm [font-family:var(--font-noto)]">
+      <p className="section-body-muted mt-3">
         記事（Writing）は文章のまとめ。登壇/書籍/コミュニティは Activities に分けています。
       </p>
 

--- a/src/content/portfolio.ts
+++ b/src/content/portfolio.ts
@@ -247,7 +247,7 @@ export const publicPortfolio: Portfolio = {
             context:
               "Developper Summit TokyoにPlatform Engineeringについてオフラインで登壇しました",
             link: {
-              label: "イベント詳細",
+              label: "DS2024",
               href: "https://event.shoeisha.jp/devsumi/20240215/session/4807",
             },
           },
@@ -275,7 +275,7 @@ export const publicPortfolio: Portfolio = {
             year: "2024",
             title: "Platform Engineering Kaigi Core Staff",
             context: "日本初となるPlatform Engineeringに関するカンファレンス開催に貢献しました。",
-            link: { label: "Platform Engineering Kaigi", href: "https://www.cnia.io/pek2024/" },
+            link: { label: "PEK2024", href: "https://www.cnia.io/pek2024/" },
           },
           {
             year: "2019-2025",
@@ -287,7 +287,7 @@ export const publicPortfolio: Portfolio = {
             year: "2022-2025",
             title: "Cloud Native Days Core Staff",
             context: "Cloud Native Daysの配信担当としてハイブリッドイベント開催に貢献しました。",
-            link: { label: "Cloud Native Days", href: "https://cloudnativedays.jp/" },
+            link: { label: "CND Home", href: "https://cloudnativedays.jp/" },
           },
         ],
       },
@@ -301,7 +301,7 @@ export const publicPortfolio: Portfolio = {
           {
             year: "2020",
             title: "第一回AWS ANGEL Dojo アライアンス賞受賞。",
-            link: { label: "AWS ANGEL Dojo", href: "https://aws.amazon.com/jp/blogs/psa/angel-dojo-season1/" },
+            link: { label: "ANGEL Dojo", href: "https://aws.amazon.com/jp/blogs/psa/angel-dojo-season1/" },
           },
           {
             year: "2021",


### PR DESCRIPTION
### Summary
- Add year/period badge token: .year-badge (font-size: 1.0rem)
- Apply to Work period badge + Activities year badge
- Keep Skills unchanged

### Verification
- pnpm lint
- pnpm build
