### PR TITLE
UI: font polish (display/body tokens)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ Unified cheat sheet so any AI agent (Claude Code, GPT, etc.) can understand the 
 | UI Library      | React / React DOM      | 19.2.0                                 | Concurrent React 19 APIs available.                               |
 | Styling         | Tailwind CSS           | 3.4.18                                 | Config in `tailwind.config.js`; `globals.css` imports directives. |
 | Theme           | NES.css                | 2.3.0                                  | Imported in layout for pixel-art UI.                              |
-| Fonts           | next/font (Google)     | Noto Sans JP, Press Start 2P           | Exposed as CSS variables `--font-noto`, `--font-press`.           |
+| Fonts           | next/font (Google)     | Noto Sans JP, Press Start 2P, DotGothic16 | Exposed as CSS variables `--font-noto`, `--font-press`, `--font-dotgothic`. |
 | Build Tools     | PostCSS + Autoprefixer | 8.5.6 / 10.4.22                        | `postcss.config.js` standard pipeline.                            |
 | Formatter       | Prettier               | ^3.x                                   | `prettier.config.cjs` + `prettier-plugin-tailwindcss`.            |
 | Linting         | ESLint                 | 9.x + `eslint-config-next`             | Config located at `eslint.config.mjs`.                            |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ Focused tips for Anthropic Claude Code / Workbench agents interacting with this 
 ## Troubleshooting
 
 - **Missing styles**: Confirm Tailwind `content` globs include new files; run `pnpm dev` again.
-- **Font issues**: Check that `var(--font-press)` / `var(--font-noto)` are used in inline styles or className as needed.
+- **Font issues**: Check that typography tokens (`--font-display` / `--font-body`) are applied (and that `--font-press` / `--font-dotgothic` / `--font-noto` are present on `<body>`).
 - **Node mismatch**: `nvm use 25.2.0`; Next.js requires >=20.9.0.
 
 ## Documentation Sync Rules (Claude)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Phase 1 of the Famicom-style portfolio for Takeshi Watanabe (Buzz). Built with N
 ## What's included now
 
 - Hero + Menu + Profile/Work/Writing/Activities/Skills/Contact sections (single-page) composed via `src/components/*`
-- Famicom palette (red `#a20000`, gold `#d7b05b`, background `#111`) and retro typography (Press Start 2P + Noto Sans JP)
+- Famicom palette (red `#a20000`, gold `#d7b05b`, background `#111`) and retro typography (Press Start 2P + DotGothic16 (display) + Noto Sans JP (body))
 - NES.css buttons, badges, and progress bars wired up for later polish
 - Menu is displayed directly under the Hero and provides in-page navigation
 - Menu is a **sticky HUD**: it stays visible while scrolling for fast section jumping

--- a/specs/027-font-polish/checklists/requirements.md
+++ b/specs/027-font-polish/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Font polish (retro readability)
+      
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2025-12-28  
+**Feature**: `specs/027-font-polish/spec.md`
+      
+## Content Quality
+      
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+      
+## Requirement Completeness
+      
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+      
+## Feature Readiness
+      
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+      
+## Notes
+      
+- None
+
+

--- a/specs/027-font-polish/contracts/README.md
+++ b/specs/027-font-polish/contracts/README.md
@@ -1,0 +1,14 @@
+# Contracts: Font polish (retro readability)
+
+**Date**: 2025-12-28  
+**Branch**: `027-font-polish`
+
+## Scope
+
+この機能はタイポグラフィ（フォント/トークン）の調整であり、外部API・JSON契約・データ入出力はありません。
+
+## Notes
+
+- N/A
+
+

--- a/specs/027-font-polish/data-model.md
+++ b/specs/027-font-polish/data-model.md
@@ -1,0 +1,22 @@
+# Data Model: Font polish (retro readability)
+
+**Date**: 2025-12-28  
+**Branch**: `027-font-polish`
+
+外部データは持たない（永続化なし）。ただし運用と一貫性のため、フォント適用ルールを“トークン”として定義する。
+
+## Entities
+
+### TypographyTokens
+
+- **fontBody**: 本文用（可読性優先）
+- **fontDisplay**: 見出し/HUD用（レトロ感優先）
+- **fontMono (optional)**: コード/数値用（必要なら）
+
+## Rules
+
+- 本文（`.section-body`, `.section-body-muted`）は `fontBody` を使用する
+- 見出し（Hero/各セクション見出し/HUD）だけ `fontDisplay` を使用する
+- フォント未取得でも、必ずフォールバックで表示が成立する
+
+

--- a/specs/027-font-polish/plan.md
+++ b/specs/027-font-polish/plan.md
@@ -1,0 +1,97 @@
+# Implementation Plan: Font polish (retro readability)
+
+**Branch**: `027-font-polish` | **Date**: 2025-12-28 | **Spec**: `specs/027-font-polish/spec.md`
+**Input**: Feature specification from `/Users/takeshiwatanabe/EureWorks/private/git/portfolio/specs/027-font-polish/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/commands/plan.md` for the execution workflow.
+
+## Summary
+
+見出し（Hero/各セクション見出し/HUD）を“よりレトロ”なフォント表現に寄せつつ、本文の可読性は維持する。
+フォント適用範囲はトークン化して一貫性を保ち、フォント読み込み失敗時もフォールバックで破綻しない構成にする。
+
+## Technical Context
+
+<!--
+  ACTION REQUIRED: Replace the content in this section with the technical details
+  for the project. The structure here is presented in advisory capacity to guide
+  the iteration process.
+-->
+
+**Language/Version**: TypeScript 5.x (Next.js App Router)  
+**Primary Dependencies**: Next.js 16, React 19, Tailwind CSS 3, NES.css, `next/font`  
+**Storage**: N/A  
+**Testing**: N/A (no automated tests; rely on `pnpm lint` + `pnpm build`)  
+**Target Platform**: Vercel  
+**Project Type**: Web application (Next.js App Router under `src/`)  
+**Performance Goals**: 文字が消えない（FOIT回避）／レイアウト崩れを最小化／新規依存追加なし  
+**Constraints**: レトロ雰囲気を強めつつ、本文の可読性（日本語）を落とさない／公開リポジトリとしてライセンス安全  
+**Scale/Scope**: Typographyのみ（見出し・HUD・本文のフォント/トークン）
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Use `.specify/memory/constitution.md` as the source of truth. This repo’s default
+gates (adapt per feature) are:
+
+- Principle compliance: changes support “Personality-First Storytelling” and do not
+  dilute the retro aesthetic + usability balance.
+- Quality gates: `pnpm lint` and `pnpm build` pass.
+- Docs sync: if dependencies/scripts/runtime/deploy/top-level UX change, update
+  `README.md`, `AGENTS.md`, and `CLAUDE.md` together.
+
+**Gate status (start)**: PASS（UX向上・可読性維持・軽量維持に合致。依存追加が必要ならDocs sync対象）
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/027-font-polish/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+```text
+src/
+├── app/
+│  ├── layout.tsx        # fonts import + root font variables
+│  └── globals.css       # typography tokens
+└── components/
+   └── sections/
+      ├── *Section.tsx   # headings (display font) + body (readable font)
+```
+
+**Structure Decision**: `next/font` でフォントを読み込み、CSS変数（トークン）として `globals.css` へ公開する。
+コンポーネント側は “トークン参照” のみでフォントを指定し、個別にフォント名を直書きしない。
+
+## Phase 0: Outline & Research (output: `research.md`)
+
+- NES.css推奨フォントの候補整理（英字/日本語）と、公開リポジトリとして安全な採用方針を確定する
+- FOIT/FOUT回避とフォールバック戦略（表示が消えない）を決める
+- 見出しと本文の “役割分離” を壊さない適用範囲（どこをdisplay fontにするか）を決める
+
+## Phase 1: Design & Contracts (output: `data-model.md`, `contracts/`, `quickstart.md`)
+
+- タイポグラフィトークン（`--font-body`, `--font-display`, etc.）を定義し、適用ルールを明文化
+- 外部APIなし（contracts は “N/A”）
+- Quickstartで「見出しがレトロ・本文が読みやすい・フォールバックが効く」を検証できる手順を書く
+
+## Phase 1b: Agent Context Update
+
+- `.specify/scripts/bash/update-agent-context.sh cursor-agent` を実行して、今回の前提（フォント/トークン）を反映する
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| [e.g., 4th project] | [current need] | [why 3 projects insufficient] |
+| [e.g., Repository pattern] | [specific problem] | [why direct DB access insufficient] |

--- a/specs/027-font-polish/quickstart.md
+++ b/specs/027-font-polish/quickstart.md
@@ -1,0 +1,36 @@
+# Quickstart: Font polish (retro readability)
+
+**Date**: 2025-12-28  
+**Branch**: `027-font-polish`
+
+## Run locally
+
+```bash
+cd /Users/takeshiwatanabe/EureWorks/private/git/portfolio
+pnpm dev
+```
+
+## Verify behavior
+
+- **Headings/HUD**
+  - Hero / MENU / 各セクション見出しが、本文と明確に違う“レトロ寄り”のフォント表現になっている
+- **Body readability**
+  - Profile/Work/Activities/Skills/Contact の本文が読みやすい（潰れ/詰まりがない）
+- **Fallback**
+  - フォントが読み込めない状況でも文字が消えず、代替フォントで内容が読める
+
+### Fallback check (manual)
+
+1. Chrome DevTools → **Network** → “Disable cache” をON
+2. DevTools → Command Menu → “Show Network request blocking”
+3. `fonts.googleapis.com` / `fonts.gstatic.com` をブロックしてリロード
+4. 文字が消えずに表示される（フォールバックで成立する）ことを確認
+
+## Quality gates
+
+```bash
+pnpm lint
+pnpm build
+```
+
+

--- a/specs/027-font-polish/research.md
+++ b/specs/027-font-polish/research.md
@@ -1,0 +1,27 @@
+# Research: Font polish (retro readability)
+
+**Date**: 2025-12-28  
+**Branch**: `027-font-polish`  
+**Spec**: `specs/027-font-polish/spec.md`
+
+## Decisions
+
+### 1) Use NES.css-compatible fonts, but keep body readable
+
+- **Decision**: 見出し/HUDは“レトロ表示用フォント”へ寄せ、本文は既存の読みやすいフォントを維持する（役割分離）。
+- **Rationale**: NES.cssは **コンポーネント提供（CSSのみ）**で、フォント自体は同梱しないため、サイト側で適切に選ぶ必要がある。雰囲気は上げつつ、長文（日本語）の可読性を守るのが最優先。  
+- **Reference**: NES.css README（フォント推奨リスト・CSS only）: [nostalgic-css/NES.css](https://github.com/nostalgic-css/NES.css)
+
+### 2) Prefer fonts with clear licensing and stable distribution
+
+- **Decision**: 公開リポジトリとして、利用条件が明確で、将来の運用でも壊れにくいフォントを優先する（不明瞭な配布/再配布条件のものは避ける）。
+- **Rationale**: フォントは配布元/ライセンスの扱いがリスクになりやすい。採用時点で“安全”を満たしておく。
+- **Alternatives considered**:
+  - 個人配布/再配布条件が曖昧なフォント: リスクが高い
+
+### 3) Avoid FOIT; always show text with a fallback chain
+
+- **Decision**: “文字が消える”体験（FOIT）を避け、フォント未取得でもフォールバックで表示が成立する方針にする。
+- **Rationale**: 読めない時間があるのはUX上のバグ。特に1ページのポートフォリオでは離脱に直結する。
+
+

--- a/specs/027-font-polish/spec.md
+++ b/specs/027-font-polish/spec.md
@@ -1,0 +1,75 @@
+# Feature Specification: Font polish (retro readability)
+
+**Feature Branch**: `027-font-polish`  
+**Created**: 2025-12-28  
+**Status**: Draft  
+**Input**: User description: "フォントの具体強化をまずはやろう"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Headings feel more “8-bit” without hurting reading (Priority: P1)
+
+閲覧者として、各セクションの見出しやHUD（MENU/ステージ表示）が、より“ゲームっぽい”フォント表現になっていて、サイトの世界観が強く感じられる一方で、本文の読みやすさは落ちないでほしい。
+
+**Why this priority**: 見出しは第一印象を決める“顔”なので、ここが整うと全体の作り込み感が一気に上がる。
+
+**Independent Test**: トップページ（Hero→Menu→各セクション）を見て、見出しがよりレトロに見える一方、本文は読みやすいまま。
+
+**Acceptance Scenarios**:
+
+1. **Given** トップページ、**When** 各セクション見出しを見る、**Then** レトロ感のある見出し表現になっている
+2. **Given** トップページ、**When** 本文を読む、**Then** 文字が潰れず読みやすい
+
+---
+
+### User Story 2 - Japanese text stays legible (Priority: P2)
+
+閲覧者として、日本語の情報が多いページでも、フォントの変更によって読みにくくならず、長文でも目が疲れにくい状態を維持してほしい。
+
+**Why this priority**: 日本語のドット系フォントは雰囲気が出る一方、読みづらくなりやすい。読みやすさを守る。
+
+**Independent Test**: Profile/Work/Activities/Skills/Contact の文章をスクロールして読んでも、可読性が維持される。
+
+**Acceptance Scenarios**:
+
+1. **Given** 長文の日本語本文、**When** スクロールして読む、**Then** 可読性が維持される（小さすぎ/潰れ/詰まりがない）
+
+---
+
+### User Story 3 - Font choice is safe and durable (Priority: P3)
+
+開発者として、導入するフォントがライセンス的に安全で、将来の運用でも“変な依存”にならず、サイトの表示が壊れにくい状態にしたい。
+
+**Why this priority**: フォントは見た目に直結し、かつライセンス/配布元変更などのリスクがあるため。
+
+**Independent Test**: フォントが読み込めない状況でも、フォールバックで表示が成立する。
+
+**Acceptance Scenarios**:
+
+1. **Given** フォントが取得できない環境、**When** ページを表示する、**Then** 代替フォントで破綻せず表示される
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: システム MUST 見出し（Hero/各セクション見出し/HUDラベル）に対して、よりレトロ感のあるフォント表現を適用する
+- **FR-002**: システム MUST 本文の可読性を維持する（本文用フォントは“読みやすさ”優先のままにする）
+- **FR-003**: システム MUST 日本語テキストの可読性を損なわない（小さすぎ/潰れ/詰まりを避ける）
+- **FR-004**: システム MUST フォントが読み込めない場合でも表示が破綻しない（フォールバックが機能する）
+- **FR-005**: システム MUST 導入するフォントの利用条件が明確で、公開リポジトリとして安全である
+- **FR-006**: システム SHOULD フォントの適用範囲をトークン化し、追加セクションでも一貫性が保てる
+
+### Edge Cases
+
+- 小さい画面や縮小表示でも、見出しが読める
+- 太字/細字がないフォントでもレイアウトが崩れない
+- ネットワークが遅い/フォントが取得できない場合でもFOIT（文字が消える）を避ける
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 見出しの“レトロ感”が増したと感じられる（見出しと本文の役割が視覚的に分離される）
+- **SC-002**: 本文の読みやすさが維持される（長文でも読み進められる）
+- **SC-003**: フォントが読み込めない状況でも内容が読める（フォールバックで破綻しない）
+- **SC-004**: `pnpm lint` と `pnpm build` が通る

--- a/specs/027-font-polish/tasks.md
+++ b/specs/027-font-polish/tasks.md
@@ -1,0 +1,90 @@
+---
+description: "Tasks for 027-font-polish"
+---
+
+# Tasks: Font polish (retro readability)
+
+**Input**: Design documents from `/Users/takeshiwatanabe/EureWorks/private/git/portfolio/specs/027-font-polish/`  
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `quickstart.md`, `contracts/README.md`
+
+**Tests**: No automated tests requested; verify via `pnpm dev` + `pnpm lint` + `pnpm build`.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm baseline health + inventory current typography usage.
+
+- [X] T001 Confirm baseline quality gates: run `pnpm lint` and `pnpm build` in `/Users/takeshiwatanabe/EureWorks/private/git/portfolio/`
+- [X] T002 [P] Inventory current font usage across headings/HUD/body in `src/app/layout.tsx`, `src/app/globals.css`, `src/components/*` (identify where `var(--font-press)` / `var(--font-noto)` is used)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Define a single source of truth for typography tokens and fallback rules.
+
+**⚠️ CRITICAL**: No user story work should begin until this phase is complete.
+
+- [X] T003 Define typography tokens for body vs display (e.g., `--font-body`, `--font-display`) in `src/app/globals.css`
+- [X] T004 Wire the chosen display/body fonts into CSS variables in `src/app/layout.tsx` (must preserve fallback behavior)
+- [X] T005 Ensure the existing body typography helpers (`.section-body`, `.section-body-muted`) consume the new body token in `src/app/globals.css`
+
+**Checkpoint**: Tokens exist and components should reference tokens rather than hardcoding font families.
+
+---
+
+## Phase 3: User Story 1 - Headings feel more “8-bit” without hurting reading (Priority: P1) 🎯 MVP
+
+**Goal**: Make headings/HUD feel more retro while keeping body readable.
+
+**Independent Test**: Top page → headings/HUD look more game-like; body text remains readable.
+
+- [X] T006 [US1] Apply display token to Hero heading areas in `src/components/Hero.tsx`
+- [X] T007 [US1] Apply display token to MENU/HUD labels in `src/components/TableOfContents.tsx` and `src/components/ScrollHud.tsx`
+- [X] T008 [US1] Apply display token to section headings in `src/components/sections/*Section.tsx` (Profile/Work/Writing/Activities/Skills/Contact)
+- [X] T009 [US1] Confirm body paragraphs remain on body token (fix any accidental display-token leakage)
+
+**Checkpoint**: US1 is shippable independently.
+
+---
+
+## Phase 4: User Story 2 - Japanese text stays legible (Priority: P2)
+
+**Goal**: Ensure Japanese-heavy pages remain legible after font polish.
+
+**Independent Test**: Read Profile/Work/Activities/Skills/Contact body text; no “crushed” glyphs or fatigue-inducing density.
+
+- [X] T010 [US2] Tune body typography for Japanese readability (line-height/letter-spacing if needed) in `src/app/globals.css` without losing retro feel
+- [X] T011 [US2] Mobile pass: verify headings don’t overflow and body remains readable; adjust only tokens/helpers in `src/app/globals.css`
+
+---
+
+## Phase 5: User Story 3 - Font choice is safe and durable (Priority: P3)
+
+**Goal**: Keep font selection safe (license) and durable (fallback works).
+
+**Independent Test**: If the display font fails to load, page is still readable; docs state what we ship.
+
+- [X] T012 [US3] Document the chosen font(s) and their license/source in `README.md` (and update `AGENTS.md` / `CLAUDE.md` only if dependency/runtime instructions change)
+- [X] T013 [US3] Validate fallback chain works (no FOIT): simulate blocked font load and confirm text still renders (document the check in `specs/027-font-polish/quickstart.md`)
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Quality gates + quickstart validation.
+
+- [X] T014 Run `pnpm lint` and fix any issues
+- [X] T015 Run `pnpm build` and fix any issues
+- [X] T016 Validate `specs/027-font-polish/quickstart.md` steps end-to-end
+
+---
+
+## Dependencies & Execution Order
+
+- Setup (T001–T002) → Foundational (T003–T005) → US1 (T006–T009) → US2 (T010–T011) → US3 (T012–T013) → Polish (T014–T016)
+
+## Parallel Opportunities
+
+- [P] inventory task (T002) can run in parallel with other baseline checks.
+
+

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,6 +6,8 @@
   color-scheme: dark;
   --menu-top: 0.75rem;
   --menu-offset: 9.5rem;
+  --font-body: var(--font-noto);
+  --font-display: var(--font-press), var(--font-dotgothic), var(--font-noto);
 }
 
 html,
@@ -157,16 +159,25 @@ body {
 /* Guardrail: avoid expensive animation patterns (keep transforms/opacity only). */
 
 /* Typography tokens */
+.font-display {
+  font-family: var(--font-display);
+}
+
+.font-body {
+  font-family: var(--font-body);
+}
+
 .section-body {
   font-size: 1rem; /* tailwind: text-base */
   line-height: 1.75rem; /* tailwind: leading-relaxed */
-  font-family: var(--font-noto);
+  font-family: var(--font-body);
+  text-rendering: geometricPrecision;
 }
 
 .section-body-muted {
   font-size: 0.875rem; /* tailwind: text-sm */
   line-height: 1.25rem;
-  font-family: var(--font-noto);
+  font-family: var(--font-body);
   color: rgba(248, 241, 220, 0.9); /* close to text-fami-ivory/90 */
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import "nes.css/css/nes.min.css";
 import type { Metadata } from "next";
-import { Noto_Sans_JP, Press_Start_2P } from "next/font/google";
+import { DotGothic16, Noto_Sans_JP, Press_Start_2P } from "next/font/google";
 import type { ReactNode } from "react";
 import "./globals.css";
 
@@ -10,6 +10,7 @@ const press = Press_Start_2P({
   subsets: ["latin"],
   variable: "--font-press",
 });
+const dotGothic = DotGothic16({ weight: "400", subsets: ["latin"], variable: "--font-dotgothic" });
 
 export const metadata: Metadata = {
   title: "Takeshi Watanabe (Buzz) – Portfolio",
@@ -26,7 +27,9 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="ja">
-      <body className={`${noto.variable} ${press.variable} text-white`}>{children}</body>
+      <body className={`${noto.variable} ${press.variable} ${dotGothic.variable} text-white`}>
+        {children}
+      </body>
     </html>
   );
 }

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -2,15 +2,14 @@ export function Hero() {
   return (
     <section className="frame bg-[#1b1b1b] p-8 text-center text-fami-ivory">
       <p
-        className="blink-soft mb-3 text-xs uppercase tracking-[0.3em] text-fami-gold"
-        style={{ fontFamily: "var(--font-press)" }}
+        className="blink-soft font-display mb-3 text-xs uppercase tracking-[0.3em] text-fami-gold"
       >
         PRESS START
       </p>
-      <h1 className="text-2xl md:text-3xl" style={{ fontFamily: "var(--font-press)" }}>
+      <h1 className="font-display text-2xl md:text-3xl">
         Takeshi Watanabe <span className="text-fami-gold">(Buzz)</span>
       </h1>
-      <p className="mt-4 text-base [font-family:var(--font-noto)] md:text-lg">
+      <p className="mt-4 text-base [font-family:var(--font-body)] md:text-lg">
         Backend Engineer with a Platform/Infra mindset—shipping reliable systems and observability.
         Also builds TypeScript full-stack and has a Data/ML background.
       </p>

--- a/src/components/ScrollHud.tsx
+++ b/src/components/ScrollHud.tsx
@@ -133,7 +133,7 @@ export function ScrollHud() {
           style={{ ["--hud-progress" as never]: `${Math.round(state.progressRatio * 100)}%` }}
         />
       </div>
-      <p className="mt-2 text-[0.65rem] uppercase tracking-[0.25em] text-fami-gold">
+      <p className="font-display mt-2 text-[0.65rem] uppercase tracking-[0.25em] text-fami-gold">
         STAGE: {idToLabel.get(state.activeSectionId) ?? state.activeSectionId}
       </p>
     </div>

--- a/src/components/TableOfContents.tsx
+++ b/src/components/TableOfContents.tsx
@@ -27,7 +27,7 @@ export function TableOfContents() {
       className="hud frame sticky top-[var(--menu-top)] z-50 bg-[#1b1b1b]/90 p-4 text-fami-ivory backdrop-blur supports-[backdrop-filter]:bg-[#1b1b1b]/70"
     >
       <div className="mb-3 flex items-baseline justify-between">
-        <h2 className="text-sm text-fami-gold" style={{ fontFamily: "var(--font-press)" }}>
+        <h2 className="font-display text-sm text-fami-gold">
           MENU
         </h2>
       </div>

--- a/src/components/sections/ActivitiesSection.tsx
+++ b/src/components/sections/ActivitiesSection.tsx
@@ -20,8 +20,7 @@ export async function ActivitiesSection() {
       className="frame scroll-mt-[var(--menu-offset)] bg-[#1b1b1b] p-6 text-fami-ivory"
     >
       <h2
-        className="flex items-center gap-2 text-xl text-fami-gold"
-        style={{ fontFamily: "var(--font-press)" }}
+        className="font-display flex items-center gap-2 text-xl text-fami-gold"
       >
         <PixelIcon src="/assets/pixel/icons/activities.svg" decorative size="md" />
         <span>{activities.heading}</span>
@@ -35,16 +34,15 @@ export async function ActivitiesSection() {
         {activities.groups.map((group) => (
           <div key={group.name}>
             <h3
-              className="text-xs uppercase tracking-[0.3em] text-fami-gold"
-              style={{ fontFamily: "var(--font-press)" }}
+              className="font-display text-xs uppercase tracking-[0.3em] text-fami-gold"
             >
               {group.name}
             </h3>
 
             {group.items.length === 0 ? (
-              <p className="mt-3 text-sm [font-family:var(--font-noto)]">Coming soon</p>
+              <p className="mt-3 text-sm [font-family:var(--font-body)]">Coming soon</p>
             ) : (
-              <ul className="mt-3 space-y-3 text-sm [font-family:var(--font-noto)]">
+              <ul className="mt-3 space-y-3 text-sm [font-family:var(--font-body)]">
                 {group.items.map((item) => (
                   <li key={`${group.name}:${item.year}:${item.title}`} className="space-y-2">
                     <div className="flex items-start justify-between gap-3">

--- a/src/components/sections/ContactSection.tsx
+++ b/src/components/sections/ContactSection.tsx
@@ -29,8 +29,7 @@ export async function ContactSection() {
       className="frame scroll-mt-[var(--menu-offset)] bg-[#1b1b1b] p-6 text-fami-ivory"
     >
       <h2
-        className="flex items-center gap-2 text-xl text-fami-gold"
-        style={{ fontFamily: "var(--font-press)" }}
+        className="font-display flex items-center gap-2 text-xl text-fami-gold"
       >
         <PixelIcon src="/assets/pixel/icons/contact.svg" decorative size="md" />
         <span>{contact.heading}</span>

--- a/src/components/sections/ProfileSection.tsx
+++ b/src/components/sections/ProfileSection.tsx
@@ -9,8 +9,7 @@ export async function ProfileSection() {
       className="frame scroll-mt-[var(--menu-offset)] bg-[#1b1b1b] p-6 text-fami-ivory"
     >
       <h2
-        className="flex items-center gap-2 text-xl text-fami-gold"
-        style={{ fontFamily: "var(--font-press)" }}
+        className="font-display flex items-center gap-2 text-xl text-fami-gold"
       >
         <PixelIcon src="/assets/pixel/icons/profile.svg" decorative size="md" />
         <span>{profile.heading}</span>

--- a/src/components/sections/SkillsSection.tsx
+++ b/src/components/sections/SkillsSection.tsx
@@ -29,8 +29,7 @@ export async function SkillsSection() {
       className="frame scroll-mt-[var(--menu-offset)] bg-[#1b1b1b] p-6 text-fami-ivory"
     >
       <h2
-        className="flex items-center gap-2 text-xl text-fami-gold"
-        style={{ fontFamily: "var(--font-press)" }}
+        className="font-display flex items-center gap-2 text-xl text-fami-gold"
       >
         <PixelIcon src="/assets/pixel/icons/skills.svg" decorative size="md" />
         <span>{skills.heading}</span>
@@ -43,8 +42,7 @@ export async function SkillsSection() {
           {categories.map((cat) => (
             <div key={cat.name}>
               <h3
-                className="text-xs uppercase tracking-[0.3em] text-fami-gold"
-                style={{ fontFamily: "var(--font-press)" }}
+                className="font-display text-xs uppercase tracking-[0.3em] text-fami-gold"
               >
                 {cat.name}
               </h3>

--- a/src/components/sections/WorkSection.tsx
+++ b/src/components/sections/WorkSection.tsx
@@ -16,8 +16,7 @@ export async function WorkSection() {
     >
       <header className="flex items-baseline justify-between">
         <h2
-          className="flex items-center gap-2 text-xl text-fami-gold"
-          style={{ fontFamily: "var(--font-press)" }}
+          className="font-display flex items-center gap-2 text-xl text-fami-gold"
         >
           <PixelIcon src="/assets/pixel/icons/work.svg" decorative size="md" />
           <span>{work.heading}</span>
@@ -29,7 +28,7 @@ export async function WorkSection() {
         会社/組織ごとに1つの文章で概要をまとめ、配下に具体的な取り組み（Projects）を載せています。
       </p>
 
-      <div className="mt-4 space-y-6 [font-family:var(--font-noto)]">
+      <div className="mt-4 space-y-6 [font-family:var(--font-body)]">
         {work.items.map((entry) => (
           <article key={entry.key} className="frame bg-[#1b1b1b] p-4">
             <div className="flex flex-wrap items-center justify-between gap-2">
@@ -38,7 +37,7 @@ export async function WorkSection() {
                   <span className="nes-badge is-primary year-badge">
                     <span>{entry.period}</span>
                   </span>
-                  <h3 className="truncate text-sm text-fami-gold" style={{ fontFamily: "var(--font-press)" }}>
+                  <h3 className="font-display truncate text-sm text-fami-gold">
                     {entry.company}
                   </h3>
                 </div>
@@ -96,7 +95,7 @@ export async function WorkSection() {
                       </div>
                     ) : null}
                     <div className="flex items-center justify-between gap-2">
-                      <h4 className="text-sm text-fami-gold" style={{ fontFamily: "var(--font-press)" }}>
+                      <h4 className="font-display text-sm text-fami-gold">
                         {project.title}
                       </h4>
                       <div className="flex items-center gap-2">

--- a/src/components/sections/WritingSection.tsx
+++ b/src/components/sections/WritingSection.tsx
@@ -13,8 +13,7 @@ export async function WritingSection() {
       className="frame scroll-mt-[var(--menu-offset)] bg-[#1b1b1b] p-6 text-fami-ivory"
     >
       <h2
-        className="flex items-center gap-2 text-xl text-fami-gold"
-        style={{ fontFamily: "var(--font-press)" }}
+        className="font-display flex items-center gap-2 text-xl text-fami-gold"
       >
         <PixelIcon src="/assets/pixel/icons/writing.svg" decorative size="md" />
         <span>{writing.heading}</span>


### PR DESCRIPTION
### What
- Introduce typography tokens: --font-display / --font-body
- Use DotGothic16 as display fallback for JP while keeping body readable
- Replace inline fontFamily usage with token classes (font-display)

### Verification
- pnpm lint
- pnpm build

### Docs synced
- README.md / AGENTS.md / CLAUDE.md
