### PR TITLE
feat: PRESS START reveal menu

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ Unified cheat sheet so any AI agent (Claude Code, GPT, etc.) can understand the 
 
 - Landing page composition lives in `src/app/page.tsx` and is intentionally thin.
 - Menu navigation is implemented via `src/components/TableOfContents.tsx` + `src/components/toc.ts`.
-- Menu is displayed directly under the Hero and provides in-page navigation.
+- Menu is revealed via a Hero **PRESS START** interaction (session-scoped), then provides in-page navigation.
 - Menu is styled as a sticky “HUD” so it remains visible while scrolling.
 - Semantic sections live under `src/components/sections/*` and each owns a stable `id`
   for in-page anchor navigation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Focused tips for Anthropic Claude Code / Workbench agents interacting with this 
 
 - `src/app/page.tsx` – Landing page composition (Hero → Menu → sections). Keep it thin; put content in sections and data in `src/content/portfolio.ts`.
 - `src/components/TableOfContents.tsx` – Menu UI (in-page navigation, sticky HUD).
-- `src/components/Hero.tsx` – Hero header (no buttons; Menu is directly below).
+- `src/components/Hero.tsx` – Hero header (includes **PRESS START** interaction that reveals the Menu; session-scoped).
 - `src/components/sections/*` – Semantic sections; each owns a stable `id` for `#hash` navigation.
 - `src/components/sections/WorkSection.tsx` – Unified Work section (company blocks with nested Projects). Work is rendered as a deliberately “unique screen” (RPG-like STATUS / QUEST LOG / DETAIL).
 - `src/components/sections/WorkQuestLog.tsx` – Client component that handles quest selection state + detail swapping (kept small on purpose).

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Famicom-style portfolio for Takeshi Watanabe (Buzz). Built with Next.js 16 + Typ
 - Hero + Menu + Profile/Work/Writing/Activities/Skills/Contact sections (single-page) composed via `src/components/*`
 - Famicom palette (red `#a20000`, gold `#d7b05b`, background `#111`) and retro typography (Press Start 2P + Noto Sans JP)
 - NES.css buttons, badges, and progress bars (plus a few CSS-only motion tokens, reduced-motion aware)
-- Menu is displayed directly under the Hero and provides in-page navigation
+- Menu is revealed via a Hero **PRESS START** interaction (session-scoped) and provides in-page navigation
 - Menu is a **sticky HUD**: it stays visible while scrolling for fast section jumping
 - Work is intentionally “different”: an RPG-style **STATUS / QUEST LOG / DETAIL** layout with keyboard-friendly quest selection
 - Activities gets a one-time **“Achievement Unlocked”** toast when first reached (dismissible; reduced-motion safe)
@@ -44,7 +44,7 @@ pnpm install
 pnpm dev
 ```
 
-Visit <http://localhost:3000> and scroll through each section to see the retro layout and interactions.
+Visit <http://localhost:3000>, press **START** in the Hero to reveal the Menu, then scroll through each section to see the retro layout and interactions.
 
 ## Scripts
 

--- a/specs/029-press-start-reveal/checklists/requirements.md
+++ b/specs/029-press-start-reveal/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Press Start Reveal
+ 
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2025-12-28  
+**Feature**: [spec.md](../spec.md)
+ 
+## Content Quality
+ 
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+ 
+## Requirement Completeness
+ 
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+ 
+## Feature Readiness
+ 
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+ 
+## Notes
+ 
+- Assumptions: “session-scoped” means the behavior persists during a single browsing session and may reset in a new session.
+

--- a/specs/029-press-start-reveal/contracts/README.md
+++ b/specs/029-press-start-reveal/contracts/README.md
@@ -1,0 +1,29 @@
+# Contracts: Press Start Reveal
+
+This feature is UI-only and does not introduce network APIs. The “contract” is the
+publicly observable DOM/CSS behavior that other components rely on.
+
+## DOM / CSS Contract
+
+### Document classes (on `<html>`)
+
+- `not-started`
+  - Meaning: The Menu/sections are locked and should be hidden/non-interactive.
+- `is-starting`
+  - Meaning: A brief boot/transition is playing.
+- `is-started`
+  - Meaning: The Menu/sections are unlocked and visible/interactive.
+
+### Start-gated wrapper
+
+- `.start-gated`
+  - Meaning: Container for content that is hidden until started.
+  - Behavior: Hidden only when the document is in `not-started` or `is-starting`.
+
+## Accessibility Contract
+
+- The START control must be keyboard-activatable.
+- After unlocking, focus must land on a predictable navigation point (Menu container or first Menu item).
+- Reduced motion preference must be respected (minimal/no animation).
+
+

--- a/specs/029-press-start-reveal/data-model.md
+++ b/specs/029-press-start-reveal/data-model.md
@@ -1,0 +1,24 @@
+# Data Model: Press Start Reveal
+
+## Entity: StartGateState
+
+Represents whether the visitor has “started” for the current browsing session.
+
+### Fields
+
+- **started**: boolean
+  - **Meaning**: Whether the Menu/sections are unlocked
+  - **Valid values**: true / false
+
+### Persistence
+
+- **Scope**: Session-scoped (resets in a new session)
+- **Data stored**: A single flag only (no personal data)
+
+### State transitions
+
+- **Initial**: `started = false` (fresh load)
+- **On START**: `started = true`
+- **On reload (same session)**: `started = true` (if previously started)
+
+

--- a/specs/029-press-start-reveal/plan.md
+++ b/specs/029-press-start-reveal/plan.md
@@ -1,0 +1,92 @@
+# Implementation Plan: Press Start Reveal
+
+**Branch**: `[029-press-start-reveal]` | **Date**: 2025-12-28 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/029-press-start-reveal/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/commands/plan.md` for the execution workflow.
+
+## Summary
+
+Add a “PRESS START” interaction on the Hero that unlocks and reveals the Menu (and all below-the-fold sections) with a short CRT/scanline-style transition. The unlocked state is remembered for the current browsing session and respects reduced motion preferences.
+
+## Technical Context
+
+<!--
+  ACTION REQUIRED: Replace the content in this section with the technical details
+  for the project. The structure here is presented in advisory capacity to guide
+  the iteration process.
+-->
+
+**Language/Version**: TypeScript 5.x  
+**Primary Dependencies**: Next.js 16 (App Router), React 19, Tailwind CSS, NES.css  
+**Storage**: Session-scoped browser storage (for a simple started flag)  
+**Testing**: No automated tests in repo yet; validate via `pnpm lint` + `pnpm build` and manual a11y checks  
+**Target Platform**: Modern browsers (desktop + mobile), deployed to Vercel  
+**Project Type**: Web application (Next.js App Router under `src/`)  
+**Performance Goals**: Transition feels instant; Menu becomes interactive within ~1s after START  
+**Constraints**: Respect reduced-motion; progressive enhancement (JS disabled remains navigable)  
+**Scale/Scope**: Single-page portfolio; feature affects only the landing page experience
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Use `.specify/memory/constitution.md` as the source of truth. This repo’s default
+gates (adapt per feature) are:
+
+- Principle compliance: changes support “Personality-First Storytelling” and do not
+  dilute the retro aesthetic + usability balance.
+- Quality gates: `pnpm lint` and `pnpm build` pass.
+- Docs sync: if dependencies/scripts/runtime/deploy/top-level UX change, update
+  `README.md`, `AGENTS.md`, and `CLAUDE.md` together.
+
+**Pass/Fail**:
+- Principle compliance: PASS (adds playful “boot” moment without removing navigation; JS-disabled remains navigable)
+- Quality gates: MUST PASS before merge (`pnpm lint`, `pnpm build`)
+- Docs sync: REQUIRED (top-level UX change)
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/029-press-start-reveal/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+<!--
+  ACTION REQUIRED: Replace the placeholder tree below with the concrete layout
+  for this feature. Delete unused options and expand the chosen structure with
+  real paths (e.g., apps/admin, packages/something). The delivered plan must
+  not include Option labels.
+-->
+
+```text
+src/
+├── app/
+│   ├── layout.tsx
+│   ├── page.tsx
+│   └── globals.css
+└── components/
+    ├── Hero.tsx
+    ├── TableOfContents.tsx
+    ├── ScrollHud.tsx
+    └── startGate.ts
+```
+
+**Structure Decision**: Next.js App Router under `src/app/*` with UI components in `src/components/*`. The “start gate” is implemented via a small shared module (`startGate.ts`), a pre-hydration class initializer in `src/app/layout.tsx`, and CSS gating/transition rules in `src/app/globals.css`.
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| [e.g., 4th project] | [current need] | [why 3 projects insufficient] |
+| [e.g., Repository pattern] | [specific problem] | [why direct DB access insufficient] |

--- a/specs/029-press-start-reveal/quickstart.md
+++ b/specs/029-press-start-reveal/quickstart.md
@@ -1,0 +1,37 @@
+# Quickstart: Press Start Reveal
+
+## Run locally
+
+```bash
+pnpm install
+pnpm dev
+```
+
+## Manual verification checklist
+
+1. **Fresh load**
+   - Confirm the Hero shows “PRESS START”.
+   - Confirm the Menu/sections are not visible yet (locked state).
+
+2. **Unlock**
+   - Activate START (mouse/tap).
+   - Confirm a short retro transition plays (or is minimal under reduced motion).
+   - Confirm the screen blocks interaction briefly during the transition (no accidental clicks).
+   - Confirm the Menu becomes visible and interactive.
+
+3. **Keyboard**
+   - Tab to START and activate with Enter/Space.
+   - Confirm focus lands on the Menu (or first Menu item) after unlock.
+
+4. **Session persistence**
+   - After unlocking, reload the page.
+   - Confirm the Menu is already unlocked.
+
+5. **Reduced motion**
+   - Enable reduced motion at OS level.
+   - Confirm unlock does not use motion-heavy effects.
+
+6. **JS disabled (progressive enhancement)**
+   - With JavaScript disabled, confirm the Menu remains visible so the portfolio is still navigable.
+
+

--- a/specs/029-press-start-reveal/research.md
+++ b/specs/029-press-start-reveal/research.md
@@ -1,0 +1,25 @@
+# Research: Press Start Reveal
+
+## Decision 1: Progressive enhancement gating
+
+- **Decision**: Hide the Menu/sections only when JavaScript successfully marks the document as “not started”.
+- **Rationale**: If JavaScript is disabled, the portfolio must remain navigable and usable (constitution: modern usability). The “PRESS START” interaction is treated as an enhancement.
+- **Alternatives considered**:
+  - Always hide via CSS by default: rejected because it breaks navigation for JS-disabled users.
+
+## Decision 2: Persist “started” state in-session
+
+- **Decision**: Store a simple started flag for the current browsing session.
+- **Rationale**: Minimizes friction while keeping the “boot” moment as a one-time interaction.
+- **Alternatives considered**:
+  - No persistence: rejected as repeated friction on reload/back.
+  - Long-term persistence: rejected as unnecessary for a portfolio UX.
+
+## Decision 3: Reduced motion handling
+
+- **Decision**: When reduced motion is enabled, unlock should skip or greatly minimize transition motion.
+- **Rationale**: Inclusive UX; avoids discomfort while preserving the interaction.
+- **Alternatives considered**:
+  - Always animate: rejected due to accessibility concerns.
+
+

--- a/specs/029-press-start-reveal/spec.md
+++ b/specs/029-press-start-reveal/spec.md
@@ -1,0 +1,119 @@
+# Feature Specification: Press Start Reveal
+
+**Feature Branch**: `[029-press-start-reveal]`  
+**Created**: 2025-12-28  
+**Status**: Draft  
+**Input**: User description: "Cの案も追加で実装して"
+
+## User Scenarios & Testing *(mandatory)*
+
+<!--
+  IMPORTANT: User stories should be PRIORITIZED as user journeys ordered by importance.
+  Each user story/journey must be INDEPENDENTLY TESTABLE - meaning if you implement just ONE of them,
+  you should still have a viable MVP (Minimum Viable Product) that delivers value.
+  
+  Assign priorities (P1, P2, P3, etc.) to each story, where P1 is the most critical.
+  Think of each story as a standalone slice of functionality that can be:
+  - Developed independently
+  - Tested independently
+  - Deployed independently
+  - Demonstrated to users independently
+-->
+
+### User Story 1 - Start to reveal navigation (Priority: P1)
+
+As a visitor landing on the page, I can press “START” from the Hero area to unlock and reveal the Menu so I can navigate the portfolio sections.
+
+**Why this priority**: The Menu is the primary wayfinding element; gating it behind a deliberate “start” interaction adds the intended game-feel while keeping the first screen focused.
+
+**Independent Test**: Load the home page fresh, press START, and verify the Menu appears and is usable for in-page navigation.
+
+**Acceptance Scenarios**:
+
+1. **Given** a fresh page load where the Menu is locked, **When** I activate the START control in the Hero, **Then** a short retro transition plays and the Menu becomes visible and interactive.
+2. **Given** the Menu is locked, **When** I activate START using the keyboard (Enter/Space), **Then** the Menu unlocks and focus is placed at the Menu (or its first item) to support keyboard navigation.
+
+---
+
+### User Story 2 - Remember “started” state for the session (Priority: P2)
+
+As a visitor who already pressed START, I don’t need to press it again when I reload or navigate back during the same browsing session.
+
+**Why this priority**: Prevents repeated friction while keeping the playful interaction as a one-time “boot” experience.
+
+**Independent Test**: Press START once, reload the page, and verify the Menu is already unlocked.
+
+**Acceptance Scenarios**:
+
+1. **Given** I have already started in this session, **When** I reload the page, **Then** the Menu is unlocked without requiring the START interaction.
+
+---
+
+### User Story 3 - Respect reduced motion (Priority: P3)
+
+As a visitor who prefers reduced motion, I can still press START to unlock the Menu, but without intensive animation.
+
+**Why this priority**: Keeps the experience inclusive and avoids discomfort while preserving the interaction.
+
+**Independent Test**: Enable reduced motion and verify START unlocks the Menu with minimal/no animation.
+
+**Acceptance Scenarios**:
+
+1. **Given** reduced motion preference is enabled, **When** I press START, **Then** the Menu unlocks immediately or with a minimal transition that does not rely on motion effects.
+
+---
+
+[Add more user stories as needed, each with an assigned priority]
+
+### Edge Cases
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right edge cases.
+-->
+
+- What happens when JavaScript is disabled and the START interaction cannot run?
+- What happens when session storage is unavailable (blocked) or throws?
+- What happens when the user activates START multiple times rapidly?
+- What happens when the user scrolls or uses anchor links before START?
+
+## Requirements *(mandatory)*
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right functional requirements.
+-->
+
+### Functional Requirements
+
+ - **FR-001**: The page MUST provide a clearly discoverable START control within the Hero area.
+ - **FR-002**: Before START, the Menu MUST be visually hidden and non-interactive (no accidental clicks/focus).
+ - **FR-003**: Activating START MUST unlock the Menu and make it visible and interactive.
+ - **FR-004**: The unlock state MUST persist for the duration of the browsing session (session-scoped).
+ - **FR-005**: The START interaction MUST be keyboard-accessible and provide a logical focus target after unlocking (Menu or first Menu item).
+ - **FR-006**: The transition MUST respect reduced motion preference by avoiding intensive motion when reduced motion is enabled.
+ - **FR-007**: If session persistence is unavailable, the feature MUST still function for the current page view (unlock works, but may not persist).
+ - **FR-008**: The feature MUST NOT store any personal data; the persisted state is limited to a simple started/unstarted flag.
+
+*Example of marking unclear requirements:*
+
+- (No [NEEDS CLARIFICATION] items for this feature.)
+
+### Key Entities *(include if feature involves data)*
+
+- **[Entity 1]**: [What it represents, key attributes without implementation]
+- **[Entity 2]**: [What it represents, relationships to other entities]
+
+## Success Criteria *(mandatory)*
+
+<!--
+  ACTION REQUIRED: Define measurable success criteria.
+  These must be technology-agnostic and measurable.
+-->
+
+### Measurable Outcomes
+
+- **SC-001**: On a fresh load, visitors can unlock the Menu within 10 seconds without needing instructions outside the page.
+- **SC-002**: After pressing START, the Menu is available for interaction within 1 second.
+- **SC-003**: Keyboard-only users can unlock the Menu and reach a Menu item without getting trapped or losing focus.
+- **SC-004**: Reduced-motion users can unlock the Menu without a motion-heavy transition.

--- a/specs/029-press-start-reveal/tasks.md
+++ b/specs/029-press-start-reveal/tasks.md
@@ -1,0 +1,137 @@
+---
+
+description: "Actionable task list for Press Start Reveal"
+---
+
+# Tasks: Press Start Reveal
+
+**Input**: Design documents from `/specs/029-press-start-reveal/`  
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/`, `quickstart.md`  
+**Tests**: Not requested (manual verification per `specs/029-press-start-reveal/quickstart.md`)
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Ensure the feature spec/contract is reflected in code structure and naming.
+
+- [X] T001 Align start-gate constants with contract in `src/components/startGate.ts`
+- [X] T002 [P] Add/confirm `.start-gated` wrapper around post-Hero content in `src/app/page.tsx`
+- [X] T003 [P] Add pre-hydration start-gate initialization (html class + session check) in `src/app/layout.tsx`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Establish the CSS contract for gating and transition visuals.
+
+**⚠️ CRITICAL**: No user story work should be considered complete until gating CSS exists (prevents accidental interaction).
+
+- [X] T004 Implement locked-state hiding + non-interactive behavior for `.start-gated` in `src/app/globals.css`
+- [X] T005 Implement transition overlay primitives (CRT/scanline look) in `src/app/globals.css`
+- [X] T006 Implement reduced-motion-safe fallbacks for the transition in `src/app/globals.css`
+
+**Checkpoint**: With JS enabled and `html.not-started`, the Menu/sections are hidden and not focusable/clickable.
+
+---
+
+## Phase 3: User Story 1 - Start to reveal navigation (Priority: P1) 🎯 MVP
+
+**Goal**: Provide a clear START control in Hero and unlock the Menu/sections with a short retro transition.
+
+**Independent Test**: Fresh load → activate START → Menu appears and can navigate to a section anchor (`specs/029-press-start-reveal/quickstart.md` steps 1–3).
+
+### Implementation
+
+- [X] T007 [US1] Convert Hero to an interactive client component and add a visible START button in `src/components/Hero.tsx`
+- [X] T008 [US1] On START, set document state to “starting” then “started” via html classes in `src/components/Hero.tsx`
+- [X] T009 [US1] After unlock, move focus to the Menu container (or first Menu item) in `src/components/Hero.tsx`
+- [X] T010 [US1] Ensure the Menu container remains a stable focus target (id/aria) in `src/components/TableOfContents.tsx`
+- [X] T011 [US1] Guard against double-activation (rapid clicks) in `src/components/Hero.tsx`
+
+**Checkpoint**: User Story 1 is fully usable without relying on session persistence.
+
+---
+
+## Phase 4: User Story 2 - Remember “started” state for the session (Priority: P2)
+
+**Goal**: After starting once, the Menu is unlocked on reload during the same session.
+
+**Independent Test**: Start once → reload → Menu is already unlocked (`specs/029-press-start-reveal/quickstart.md` step 4).
+
+### Implementation
+
+- [X] T012 [US2] Persist started flag to session storage on unlock in `src/components/Hero.tsx`
+- [X] T013 [US2] Ensure layout pre-hydration script reads the same key and sets html class accordingly in `src/app/layout.tsx`
+- [X] T014 [US2] Handle storage failures gracefully (unlock still works for this view) in `src/components/Hero.tsx`
+
+**Checkpoint**: User Story 2 works even if storage is blocked (may not persist, but unlock works).
+
+---
+
+## Phase 5: User Story 3 - Respect reduced motion (Priority: P3)
+
+**Goal**: Reduced-motion users can unlock without motion-heavy transition.
+
+**Independent Test**: Reduced motion enabled → press START → unlock works with minimal/no animation (`specs/029-press-start-reveal/quickstart.md` step 5).
+
+### Implementation
+
+- [X] T015 [US3] Ensure transition timing/effects are minimal under reduced motion in `src/app/globals.css`
+- [X] T016 [US3] Ensure START still unlocks instantly (or near-instant) under reduced motion in `src/components/Hero.tsx`
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation sync + quality gates + small UX details.
+
+- [X] T017 [P] Sync top-level UX docs for “PRESS START reveals Menu” in `README.md`
+- [X] T018 [P] Sync agent playbook notes for the new UX/gating behavior in `AGENTS.md`
+- [X] T019 [P] Sync Claude boot/dev guidance if needed for the new UX behavior in `CLAUDE.md`
+- [X] T020 Add a quick manual verification note (what to look for) in `specs/029-press-start-reveal/quickstart.md`
+- [X] T021 Validate quality gates locally (`pnpm lint`, `pnpm build`) and fix issues in `package.json`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)** → **Phase 2 (Foundational)** → **US1 (MVP)** → **US2** → **US3** → **Polish**
+
+### User Story Dependencies
+
+- **US1**: Depends on Phase 2 gating CSS being present.
+- **US2**: Builds on US1 by persisting started state; should not change the basic unlock UX.
+- **US3**: Largely independent once US1 exists; mostly CSS + a small runtime shortcut for reduced motion.
+
+### Parallel Opportunities
+
+- Tasks marked **[P]** can be done in parallel safely (different files / minimal coupling).
+
+---
+
+## Parallel Example: MVP (US1)
+
+```bash
+# In parallel:
+Task: "Implement locked-state hiding + non-interactive behavior for .start-gated in src/app/globals.css"
+Task: "Convert Hero to an interactive client component and add a visible START button in src/components/Hero.tsx"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete **Phase 1–2** (gating + transition foundations)
+2. Complete **US1**
+3. Stop and validate manually via `specs/029-press-start-reveal/quickstart.md` steps 1–3
+
+### Incremental Delivery
+
+1. Add **US2** (session persistence) and validate step 4
+2. Add **US3** (reduced motion) and validate step 5
+3. Finish docs + `pnpm lint`/`pnpm build` before merge
+
+

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -17,6 +17,92 @@ body {
   background: #111;
 }
 
+/* Start gate (PRESS START reveal)
+   Progressive enhancement: content is visible by default and only gated when JS
+   adds `html.not-started` / `html.is-starting`. */
+html.not-started .start-gated,
+html.is-starting .start-gated {
+  display: none;
+}
+
+html.is-starting body::before,
+html.is-starting body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  pointer-events: auto;
+}
+
+/* Scanlines + subtle phosphor tint */
+html.is-starting body::before {
+  background-image:
+    repeating-linear-gradient(
+      to bottom,
+      rgba(0, 0, 0, 0.0) 0px,
+      rgba(0, 0, 0, 0.0) 2px,
+      rgba(0, 0, 0, 0.18) 3px,
+      rgba(0, 0, 0, 0.18) 4px
+    ),
+    linear-gradient(180deg, rgba(215, 176, 91, 0.10), rgba(0, 0, 0, 0));
+  mix-blend-mode: multiply;
+  opacity: 0.9;
+}
+
+/* Boot flash + vignette */
+html.is-starting body::after {
+  background:
+    radial-gradient(circle at 50% 40%, rgba(255, 255, 255, 0.20), rgba(0, 0, 0, 0) 55%),
+    radial-gradient(circle at 50% 50%, rgba(0, 0, 0, 0) 45%, rgba(0, 0, 0, 0.65) 100%);
+  opacity: 0.0;
+}
+
+@keyframes start-gate-flash {
+  0% {
+    opacity: 0.0;
+  }
+  30% {
+    opacity: 0.95;
+  }
+  100% {
+    opacity: 0.0;
+  }
+}
+
+@keyframes start-gate-jitter {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0);
+  }
+  25% {
+    transform: translate3d(0, -1px, 0);
+  }
+  55% {
+    transform: translate3d(0, 1px, 0);
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  html.is-starting body::before {
+    animation: start-gate-jitter 220ms steps(2, end) infinite;
+    will-change: transform;
+  }
+  html.is-starting body::after {
+    animation: start-gate-flash 520ms steps(3, end) both;
+    will-change: opacity;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html.is-starting body::before,
+  html.is-starting body::after {
+    animation: none !important;
+  }
+  html.is-starting body::after {
+    opacity: 0.15;
+  }
+}
+
 .frame {
   border: 4px solid #d7b05b;
   box-shadow: 4px 4px 0 #a20000;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,14 @@
 import "nes.css/css/nes.min.css";
 import type { Metadata } from "next";
 import { Noto_Sans_JP, Press_Start_2P } from "next/font/google";
+import Script from "next/script";
 import type { ReactNode } from "react";
 import "./globals.css";
+import {
+  START_GATE_CLASS_NOT_STARTED,
+  START_GATE_CLASS_STARTED,
+  START_GATE_STORAGE_KEY,
+} from "@/components/startGate";
 
 const noto = Noto_Sans_JP({ subsets: ["latin"], variable: "--font-noto" });
 const press = Press_Start_2P({
@@ -25,8 +31,23 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="ja">
-      <body className={`${noto.variable} ${press.variable} text-white`}>{children}</body>
+    <html lang="ja" suppressHydrationWarning>
+      <body className={`${noto.variable} ${press.variable} text-white`}>
+        <Script id="start-gate-init" strategy="beforeInteractive">{`
+(function () {
+  try {
+    var key = ${JSON.stringify(START_GATE_STORAGE_KEY)};
+    var started = sessionStorage.getItem(key) === "1";
+    var root = document.documentElement;
+    if (started) root.classList.add(${JSON.stringify(START_GATE_CLASS_STARTED)});
+    else root.classList.add(${JSON.stringify(START_GATE_CLASS_NOT_STARTED)});
+  } catch (e) {
+    document.documentElement.classList.add(${JSON.stringify(START_GATE_CLASS_NOT_STARTED)});
+  }
+})();
+        `}</Script>
+        {children}
+      </body>
     </html>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,13 +12,15 @@ export default function Home() {
     <div className="min-h-screen bg-[#111] px-4 py-10 [--menu-offset:9.5rem] [--menu-top:0.75rem] md:px-8 md:[--menu-offset:8rem] md:[--menu-top:1rem]">
       <div className="mx-auto flex w-full max-w-5xl flex-col gap-10">
         <Hero />
-        <TableOfContents />
-        <ProfileSection />
-        <WorkSection />
-        <WritingSection />
-        <ActivitiesSection />
-        <SkillsSection />
-        <ContactSection />
+        <div className="start-gated flex flex-col gap-10">
+          <TableOfContents />
+          <ProfileSection />
+          <WorkSection />
+          <WritingSection />
+          <ActivitiesSection />
+          <SkillsSection />
+          <ContactSection />
+        </div>
       </div>
     </div>
   );

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,11 +1,102 @@
+"use client";
+
+import { useRef, useSyncExternalStore } from "react";
+import {
+  START_GATE_CLASS_NOT_STARTED,
+  START_GATE_CLASS_STARTED,
+  START_GATE_CLASS_STARTING,
+  START_GATE_EVENT,
+  START_GATE_STORAGE_KEY,
+} from "@/components/startGate";
+
+function isReducedMotionPreferred() {
+  if (typeof window === "undefined") return false;
+  return Boolean(window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches);
+}
+
+function focusMenu(reducedMotion: boolean) {
+  if (typeof document === "undefined") return;
+  const menu = document.getElementById("menu") as HTMLElement | null;
+  if (!menu) return;
+  menu.scrollIntoView({ block: "start", behavior: reducedMotion ? "auto" : "smooth" });
+  menu.focus({ preventScroll: true });
+}
+
+function subscribeStartGate(onStoreChange: () => void) {
+  if (typeof window === "undefined") return () => {};
+  window.addEventListener(START_GATE_EVENT, onStoreChange);
+  return () => window.removeEventListener(START_GATE_EVENT, onStoreChange);
+}
+
+function getStartGateSnapshot() {
+  if (typeof document === "undefined") return false;
+  return document.documentElement.classList.contains(START_GATE_CLASS_STARTED);
+}
+
+function getStartGateServerSnapshot() {
+  return false;
+}
+
+function useStartGateStarted() {
+  return useSyncExternalStore(subscribeStartGate, getStartGateSnapshot, getStartGateServerSnapshot);
+}
+
 export function Hero() {
+  const started = useStartGateStarted();
+  const startingRef = useRef(false);
+
+  function unlock() {
+    const root = document.documentElement;
+
+    root.classList.remove(START_GATE_CLASS_NOT_STARTED);
+    root.classList.remove(START_GATE_CLASS_STARTING);
+    root.classList.add(START_GATE_CLASS_STARTED);
+    window.dispatchEvent(new Event(START_GATE_EVENT));
+  }
+
+  function onStart() {
+    if (startingRef.current) return;
+    const root = document.documentElement;
+    const reducedMotion = isReducedMotionPreferred();
+
+    if (root.classList.contains(START_GATE_CLASS_STARTED)) {
+      window.dispatchEvent(new Event(START_GATE_EVENT));
+      focusMenu(reducedMotion);
+      return;
+    }
+
+    startingRef.current = true;
+
+    try {
+      sessionStorage.setItem(START_GATE_STORAGE_KEY, "1");
+    } catch {
+      // Graceful: unlock still works for this view, but may not persist.
+    }
+
+    root.classList.remove(START_GATE_CLASS_NOT_STARTED);
+
+    if (reducedMotion) {
+      unlock();
+      focusMenu(true);
+      startingRef.current = false;
+      return;
+    }
+
+    root.classList.add(START_GATE_CLASS_STARTING);
+    window.setTimeout(() => {
+      unlock();
+      focusMenu(false);
+      startingRef.current = false;
+    }, 520);
+  }
+
   return (
     <section className="frame bg-[#1b1b1b] p-8 text-center text-fami-ivory">
       <p
         className="blink-soft mb-3 text-xs uppercase tracking-[0.3em] text-fami-gold"
         style={{ fontFamily: "var(--font-press)" }}
       >
-        PRESS START
+        {started ? "READY" : "PRESS START"}
       </p>
       <h1 className="text-2xl md:text-3xl" style={{ fontFamily: "var(--font-press)" }}>
         Takeshi Watanabe <span className="text-fami-gold">(Buzz)</span>
@@ -14,6 +105,19 @@ export function Hero() {
         Backend Engineer with a Platform/Infra mindset—shipping reliable systems and observability.
         Also builds TypeScript full-stack and has a Data/ML background.
       </p>
+
+      {!started ? (
+        <div className="mt-6">
+          <button
+            type="button"
+            className="nes-btn is-primary btn-game"
+            onClick={onStart}
+            aria-label="Press Start to reveal the menu"
+          >
+            START
+          </button>
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/src/components/ScrollHud.tsx
+++ b/src/components/ScrollHud.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { TOC_ITEMS, type TocItemId } from "@/components/toc";
+import { START_GATE_EVENT } from "@/components/startGate";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 type ScrollHudState = {
@@ -106,6 +107,14 @@ export function ScrollHud() {
       });
     };
 
+    const onStartGate = () => {
+      // When gated content becomes visible, offsets must be recomputed.
+      window.requestAnimationFrame(() => {
+        computeOffsets();
+        update();
+      });
+    };
+
     const onResize = () => {
       computeOffsets();
       onScroll();
@@ -113,6 +122,7 @@ export function ScrollHud() {
 
     window.addEventListener("scroll", onScroll, { passive: true });
     window.addEventListener("resize", onResize);
+    window.addEventListener(START_GATE_EVENT, onStartGate);
 
     return () => {
       if (rafRef.current != null) {
@@ -121,6 +131,7 @@ export function ScrollHud() {
       }
       window.removeEventListener("scroll", onScroll);
       window.removeEventListener("resize", onResize);
+      window.removeEventListener(START_GATE_EVENT, onStartGate);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/src/components/TableOfContents.tsx
+++ b/src/components/TableOfContents.tsx
@@ -24,6 +24,7 @@ export function TableOfContents() {
     <nav
       id="menu"
       aria-label="Menu"
+      tabIndex={-1}
       className="hud frame sticky top-[var(--menu-top)] z-50 bg-[#1b1b1b]/90 p-4 text-fami-ivory backdrop-blur supports-[backdrop-filter]:bg-[#1b1b1b]/70"
     >
       <div className="mb-3 flex items-baseline justify-between">

--- a/src/components/startGate.ts
+++ b/src/components/startGate.ts
@@ -1,0 +1,8 @@
+export const START_GATE_STORAGE_KEY = "portfolio.started.v1";
+
+export const START_GATE_CLASS_NOT_STARTED = "not-started";
+export const START_GATE_CLASS_STARTING = "is-starting";
+export const START_GATE_CLASS_STARTED = "is-started";
+
+export const START_GATE_EVENT = "start-gate-change";
+


### PR DESCRIPTION
## What\n- Add Hero PRESS START that unlocks and reveals the sticky Menu + sections\n- CRT/scanline-style boot transition (reduced-motion safe)\n- Session-scoped persistence\n- Fix hydration mismatches + HUD (ScrollHud) recompute on unlock\n\n## Verification\n- pnpm lint (pass)\n- pnpm build (pass)\n\n## Notes\n- Docs synced: README.md / AGENTS.md / CLAUDE.md