### PR TITLE
chore: de-duplicate Hero/Profile copy

### DIFF
--- a/specs/030-hero-profile-dedupe/contracts/README.md
+++ b/specs/030-hero-profile-dedupe/contracts/README.md
@@ -1,0 +1,17 @@
+# Contracts: Hero/Profile 역할 분리
+
+This feature does not introduce network APIs. The “contract” is content and IA behavior.
+
+## Content Contract
+
+- **Hero**: Must remain concise and focused on identity/role + primary CTA (START).
+- **Profile**: Must add additional context not already stated in Hero.
+- **No duplication**: No verbatim repeated sentences between Hero and Profile.
+
+## Copy Ownership (to avoid future regressions)
+
+- **Hero copy** lives in `src/components/Hero.tsx` and should stay “one-screen scannable”.
+- **Profile copy** lives in `src/content/portfolio.ts` (`publicPortfolio.profile.body`) and can be longer narrative context.
+- When updating Profile content, avoid pasting the same sentence into Hero; keep Hero as a short lede + CTA.
+
+

--- a/specs/030-hero-profile-dedupe/data-model.md
+++ b/specs/030-hero-profile-dedupe/data-model.md
@@ -1,0 +1,5 @@
+# Data Model: Hero/Profile 역할 분리
+
+No new data entities are introduced. This feature changes copy boundaries and content ownership only.
+
+

--- a/specs/030-hero-profile-dedupe/plan.md
+++ b/specs/030-hero-profile-dedupe/plan.md
@@ -1,0 +1,91 @@
+# Implementation Plan: Hero/Profile 역할 분리
+
+**Branch**: `[030-hero-profile-dedupe]` | **Date**: 2025-12-29 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/030-hero-profile-dedupe/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/commands/plan.md` for the execution workflow.
+
+## Summary
+
+Adjust copy ownership and structure so the Hero and Profile sections stop repeating the same claims. Keep the Hero scannable and focused on the “PRESS START” interaction, while Profile provides expanded context.
+
+## Technical Context
+
+<!--
+  ACTION REQUIRED: Replace the content in this section with the technical details
+  for the project. The structure here is presented in advisory capacity to guide
+  the iteration process.
+-->
+
+**Language/Version**: TypeScript 5.x  
+**Primary Dependencies**: Next.js 16 (App Router), React 19, Tailwind CSS, NES.css  
+**Storage**: N/A  
+**Testing**: No automated tests; validate via `pnpm lint` + `pnpm build` and manual copy review  
+**Target Platform**: Modern browsers, deployed to Vercel  
+**Project Type**: Web application (Next.js App Router under `src/`)  
+**Performance Goals**: No regression (copy-only + minimal component changes)  
+**Constraints**: Maintain accessibility and scannability; avoid hydration issues (no server/client divergent text)  
+**Scale/Scope**: Only Hero/Profile copy + their content source boundaries
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Use `.specify/memory/constitution.md` as the source of truth. This repo’s default
+gates (adapt per feature) are:
+
+- Principle compliance: changes support “Personality-First Storytelling” and do not
+  dilute the retro aesthetic + usability balance.
+- Quality gates: `pnpm lint` and `pnpm build` pass.
+- Docs sync: if dependencies/scripts/runtime/deploy/top-level UX change, update
+  `README.md`, `AGENTS.md`, and `CLAUDE.md` together.
+
+**Pass/Fail (expected)**:
+- Principle compliance: PASS (improves storytelling clarity; reduces redundancy)
+- Quality gates: MUST PASS before merge (`pnpm lint`, `pnpm build`)
+- Docs sync: Not expected (no dependency/workflow/top-level UX change), unless copy ownership changes documented conventions
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/030-hero-profile-dedupe/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+<!--
+  ACTION REQUIRED: Replace the placeholder tree below with the concrete layout
+  for this feature. Delete unused options and expand the chosen structure with
+  real paths (e.g., apps/admin, packages/something). The delivered plan must
+  not include Option labels.
+-->
+
+```text
+src/
+├── app/
+│   └── page.tsx
+├── components/
+│   └── Hero.tsx
+├── components/sections/
+│   └── ProfileSection.tsx
+└── content/
+    └── portfolio.ts
+```
+
+**Structure Decision**: Copy boundaries are adjusted across `Hero.tsx` and the Profile content returned by `getPortfolio()` (server-side content). The implementation should avoid creating server/client divergent text during SSR/hydration.
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| [e.g., 4th project] | [current need] | [why 3 projects insufficient] |
+| [e.g., Repository pattern] | [specific problem] | [why direct DB access insufficient] |

--- a/specs/030-hero-profile-dedupe/quickstart.md
+++ b/specs/030-hero-profile-dedupe/quickstart.md
@@ -1,0 +1,23 @@
+# Quickstart: Hero/Profile 역할 분리
+
+## Run locally
+
+```bash
+pnpm install
+pnpm dev
+```
+
+## Manual verification
+
+1. Read Hero copy only:
+   - It should be concise and scannable.
+   - START CTA remains visually primary.
+
+2. Read Profile copy after Hero:
+   - It should add new information (no repeated sentences).
+
+3. Run verification:
+   - `pnpm lint`
+   - `pnpm build`
+
+

--- a/specs/030-hero-profile-dedupe/research.md
+++ b/specs/030-hero-profile-dedupe/research.md
@@ -1,0 +1,24 @@
+# Research: Hero/Profile 역할 분리
+
+## Decision 1: 明確な役割分担（情報の粒度）
+
+- **Decision**: Hero は「一文の役割/軸 + START CTA」に集中し、Profile は「背景/強み/価値観の補足」に寄せる。
+- **Rationale**: 一番上の画面はスキャン性能が重要。重複排除でストーリーが前に進む。
+- **Alternatives considered**:
+  - Hero を長文にして Profile を短くする: START CTA の視認性が下がるため不採用。
+
+## Decision 2: Copy の単一責任（更新コスト）
+
+- **Decision**: “同じ主張の再掲” を避けるため、コピーの責任範囲を定義し、更新時の二重編集が起きにくい構造にする。
+- **Rationale**: 今後のコンテンツ更新時に、重複が再発しやすい。
+- **Alternatives considered**:
+  - その都度手動でコピペ調整: 再発リスクが高い。
+
+## Decision 3: SSR/hydration の安全性
+
+- **Decision**: サーバー/クライアントでテキストが変わる分岐を避ける（特に Hero は hydration mismatch を起こしやすい）。
+- **Rationale**: 既存で hydration mismatch を経験済み。コピー変更でも再発し得る。
+- **Alternatives considered**:
+  - `typeof window` でレンダー分岐: mismatch の温床になりやすい。
+
+

--- a/specs/030-hero-profile-dedupe/spec.md
+++ b/specs/030-hero-profile-dedupe/spec.md
@@ -1,0 +1,110 @@
+# Feature Specification: Hero/Profile 역할 분리
+
+**Feature Branch**: `[030-hero-profile-dedupe]`  
+**Created**: 2025-12-29  
+**Status**: Draft  
+**Input**: User description: "Hero.tsx と ProfileSection.tsx の内容がかなり被っている気がするので変えたい。"
+
+## User Scenarios & Testing *(mandatory)*
+
+<!--
+  IMPORTANT: User stories should be PRIORITIZED as user journeys ordered by importance.
+  Each user story/journey must be INDEPENDENTLY TESTABLE - meaning if you implement just ONE of them,
+  you should still have a viable MVP (Minimum Viable Product) that delivers value.
+  
+  Assign priorities (P1, P2, P3, etc.) to each story, where P1 is the most critical.
+  Think of each story as a standalone slice of functionality that can be:
+  - Developed independently
+  - Tested independently
+  - Deployed independently
+  - Demonstrated to users independently
+-->
+
+### User Story 1 - First screen communicates “who” without repeating “about” (Priority: P1)
+
+As a first-time visitor, I can understand who the person is and what they do from the first screen (Hero) without seeing duplicated text that is repeated again in the Profile section.
+
+**Why this priority**: The first screen sets the tone; duplication reduces clarity and makes the page feel less intentional.
+
+**Independent Test**: Read only the Hero + Profile sections and confirm they each add distinct information (no repeated sentences/claims).
+
+**Acceptance Scenarios**:
+
+1. **Given** the page is loaded, **When** I read Hero and then Profile, **Then** I do not encounter the same description repeated verbatim (or near-verbatim).
+2. **Given** the page is loaded, **When** I read Hero and then Profile, **Then** Hero gives a concise role/identity and Profile expands with additional context that is not already stated.
+
+---
+
+### User Story 2 - Keep “Press Start” hero interaction focused (Priority: P2)
+
+As a visitor, I can still use the Hero “PRESS START” interaction without the Hero becoming text-heavy; the interaction remains the primary call-to-action and the copy remains scannable.
+
+**Why this priority**: The game-feel interaction should not compete with long copy above the fold.
+
+**Independent Test**: On mobile and desktop, verify that Hero copy remains brief and the START control remains visually prominent.
+
+**Acceptance Scenarios**:
+
+1. **Given** a mobile viewport, **When** I view the Hero, **Then** the START call-to-action is immediately visible without excessive scrolling.
+
+---
+
+### User Story 3 - Maintain tone and readability (Priority: P3)
+
+As a visitor, the adjusted copy still feels consistent with the retro theme, and remains readable and accessible.
+
+**Why this priority**: Copy changes must not degrade the site’s tone or usability.
+
+**Independent Test**: Verify the updated copy is readable, concise, and does not introduce awkward line breaks or overly dense paragraphs.
+
+**Acceptance Scenarios**:
+
+1. **Given** the updated copy, **When** I navigate the page, **Then** headings and paragraphs remain readable and well-structured.
+
+---
+
+[Add more user stories as needed, each with an assigned priority]
+
+### Edge Cases
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right edge cases.
+-->
+
+- What happens when Profile content is edited in the content source—does Hero remain distinct without manual double-updating?
+- What happens when text length grows (Japanese/English mix)—does the Hero remain scannable?
+
+## Requirements *(mandatory)*
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right functional requirements.
+-->
+
+### Functional Requirements
+
+- **FR-001**: The Hero section MUST communicate a concise identity/role without repeating the Profile section’s copy.
+- **FR-002**: The Profile section MUST provide additional context beyond what is already stated in the Hero.
+- **FR-003**: The Hero MUST remain scannable (no dense paragraphs that compete with the primary call-to-action).
+- **FR-004**: The change MUST NOT remove or reduce the existing “PRESS START” interaction’s clarity.
+- **FR-005**: Copy updates MUST preserve readability and accessibility (clear hierarchy, readable line lengths).
+
+*No [NEEDS CLARIFICATION] items for this feature.*
+
+### Key Entities *(include if feature involves data)*
+
+*(No new data entities; this feature is copy/structure only.)*
+
+## Success Criteria *(mandatory)*
+
+<!--
+  ACTION REQUIRED: Define measurable success criteria.
+  These must be technology-agnostic and measurable.
+-->
+
+### Measurable Outcomes
+
+- **SC-001**: Hero and Profile contain **0** verbatim repeated sentences.
+- **SC-002**: On mobile, the START call-to-action remains visible without scrolling on initial load.
+- **SC-003**: Readers can understand “what you do” from Hero in under 10 seconds, and “more detail” from Profile in under 30 seconds.

--- a/specs/030-hero-profile-dedupe/tasks.md
+++ b/specs/030-hero-profile-dedupe/tasks.md
@@ -1,0 +1,119 @@
+---
+
+description: "Actionable task list for Hero/Profile de-duplication"
+---
+
+# Tasks: Hero/Profile 역할 분리
+
+**Input**: Design documents from `/specs/030-hero-profile-dedupe/`  
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `contracts/`, `quickstart.md`  
+**Tests**: Not requested (manual verification per `specs/030-hero-profile-dedupe/quickstart.md`)
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Establish a safe workflow for copy changes without reintroducing hydration issues.
+
+- [X] T001 Add a short “copy ownership” note in `specs/030-hero-profile-dedupe/contracts/README.md`
+- [X] T002 [P] Identify duplicated sentences between Hero and Profile (current baseline) in `src/components/Hero.tsx`
+- [X] T003 [P] Identify duplicated sentences between Hero and Profile (current baseline) in `src/components/sections/ProfileSection.tsx`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Ensure copy updates won’t create SSR/hydration mismatch regressions.
+
+- [X] T004 Confirm Hero text rendered during SSR is stable (no server/client divergent copy) in `src/components/Hero.tsx`
+- [X] T005 Confirm Profile remains server-rendered and stable (no client-only variation) in `src/components/sections/ProfileSection.tsx`
+
+**Checkpoint**: Hero/Profile copy can be changed without introducing hydration mismatch warnings.
+
+---
+
+## Phase 3: User Story 1 - First screen communicates “who” without repeating “about” (Priority: P1) 🎯 MVP
+
+**Goal**: Remove duplicated copy and make Hero vs Profile contributions clearly distinct.
+
+**Independent Test**: Read Hero + Profile; confirm no repeated sentences and each section adds distinct information (`specs/030-hero-profile-dedupe/quickstart.md` steps 1–2).
+
+### Implementation
+
+- [X] T006 [US1] Rewrite Hero body copy to be a concise identity/role statement (no Profile repetition) in `src/components/Hero.tsx`
+- [X] T007 [US1] Rewrite Profile body copy to add new context beyond Hero (no repetition) in `src/components/sections/ProfileSection.tsx`
+- [X] T008 [US1] Ensure “0 verbatim repeated sentences” success criterion is met (manual check) in `specs/030-hero-profile-dedupe/quickstart.md`
+
+**Checkpoint**: US1 complete; duplication removed.
+
+---
+
+## Phase 4: User Story 2 - Keep “Press Start” hero interaction focused (Priority: P2)
+
+**Goal**: Hero remains scannable and START CTA remains primary, especially on mobile.
+
+**Independent Test**: Mobile viewport: START CTA visible without scrolling, and Hero copy remains brief (`specs/030-hero-profile-dedupe/quickstart.md` step 1).
+
+### Implementation
+
+- [X] T009 [US2] Ensure Hero copy stays short (no dense paragraph) and CTA prominence is preserved in `src/components/Hero.tsx`
+- [X] T010 [US2] Adjust spacing/typography if needed to avoid pushing START below fold on mobile in `src/components/Hero.tsx`
+
+---
+
+## Phase 5: User Story 3 - Maintain tone and readability (Priority: P3)
+
+**Goal**: Keep tone consistent with the retro theme and maintain readability.
+
+**Independent Test**: Readability check across desktop/mobile; no awkward line breaks or overly dense paragraphs.
+
+### Implementation
+
+- [X] T011 [US3] Review updated copy for tone consistency and readability in `src/components/Hero.tsx`
+- [X] T012 [US3] Review updated copy for tone consistency and readability in `src/components/sections/ProfileSection.tsx`
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Validation gates.
+
+- [X] T013 Run manual verification steps in `specs/030-hero-profile-dedupe/quickstart.md`
+- [X] T014 Run `pnpm lint` and fix any issues in `src/components/Hero.tsx` and `src/components/sections/ProfileSection.tsx`
+- [X] T015 Run `pnpm build` and fix any issues in `src/components/Hero.tsx` and `src/components/sections/ProfileSection.tsx`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)** → **Foundational (Phase 2)** → **US1 (MVP)** → **US2** → **US3** → **Polish**
+
+### User Story Dependencies
+
+- **US1**: Requires Phase 2 guardrails (avoid hydration regressions).
+- **US2/US3**: Build on US1 copy split, but can be iterated lightly without changing structure.
+
+### Parallel Opportunities
+
+- T002 and T003 can run in parallel (different files).
+
+---
+
+## Parallel Example: MVP (US1)
+
+```bash
+Task: "Identify duplicated sentences in src/components/Hero.tsx"
+Task: "Identify duplicated sentences in src/components/sections/ProfileSection.tsx"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1–2
+2. Complete US1
+3. Validate manually + run `pnpm lint`/`pnpm build`
+
+

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useRef, useSyncExternalStore } from "react";
 import {
   START_GATE_CLASS_NOT_STARTED,
   START_GATE_CLASS_STARTED,
@@ -8,6 +7,7 @@ import {
   START_GATE_EVENT,
   START_GATE_STORAGE_KEY,
 } from "@/components/startGate";
+import { useRef, useSyncExternalStore } from "react";
 
 function isReducedMotionPreferred() {
   if (typeof window === "undefined") return false;
@@ -102,8 +102,7 @@ export function Hero() {
         Takeshi Watanabe <span className="text-fami-gold">(Buzz)</span>
       </h1>
       <p className="mt-4 text-base [font-family:var(--font-noto)] md:text-lg">
-        Backend Engineer with a Platform/Infra mindset—shipping reliable systems and observability.
-        Also builds TypeScript full-stack and has a Data/ML background.
+      Software Engineer @ eureka_inc | Match Group | Go | TypeScript | Terraform | AWS | Google Cloud | strong interest in system reliability and architecture
       </p>
 
       {!started ? (

--- a/src/components/sections/ProfileSection.tsx
+++ b/src/components/sections/ProfileSection.tsx
@@ -1,5 +1,5 @@
-import { getPortfolio } from "@/content/portfolio";
 import { PixelIcon } from "@/components/PixelIcon";
+import { getPortfolio } from "@/content/portfolio";
 
 export async function ProfileSection() {
   const { profile } = await getPortfolio();
@@ -15,7 +15,7 @@ export async function ProfileSection() {
         <PixelIcon src="/assets/pixel/icons/profile.svg" decorative size="md" />
         <span>{profile.heading}</span>
       </h2>
-      <p className="section-body mt-3">{profile.body}</p>
+      <p className="section-body mt-4 whitespace-pre-line">{profile.body}</p>
     </section>
   );
 }

--- a/src/content/portfolio.ts
+++ b/src/content/portfolio.ts
@@ -148,8 +148,8 @@ export const publicPortfolio: Portfolio = {
     id: "profile",
     heading: "Profile",
     body:
-      "Machine Learning Engineer、Data Scientist、Infrastructure Engineer、Platform Engineer などの職種を経験してきました。現在は株式会社エウレカにて Backend Engineer として、主に Go を用いた開発に携わっています。\n\n" +
-      "また、エウレカ以外では副業として、サービス立ち上げ当初からインフラ基盤をゼロから構築したり、TypeScript を用いたフルスタック開発にも取り組んでいます。",
+      "Machine Learning Engineer、Data Scientist、Infrastructure Engineer、Platform Engineer などの職種を経験してきました。現在は株式会社エウレカで、Go を中心にバックエンド開発に携わっています。" +
+      "副業では、サービス立ち上げ初期からインフラ基盤をゼロから構築したり、TypeScript を用いたフルスタック開発にも取り組んでいます",
   },
   work: {
     id: "work",


### PR DESCRIPTION
## What\n- Reduce overlap between Hero and Profile copy\n- Keep Hero scannable and CTA-forward\n- Improve Profile readability (whitespace formatting)\n\n## Verification\n- pnpm lint (pass)\n- pnpm build (pass)\n\n## Spec artifacts\n- specs/030-hero-profile-dedupe/*