### PR TITLE
docs: speckit plan and tasks for 039-fix-hydration-error

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,8 @@ pnpm format:check && pnpm lint && pnpm build
 - Static file in `public/assets/` directory (no database) (037-hero-image)
 - TypeScript 5.x + Next.js 16.0.7, React 19.2.1, Tailwind CSS 3.4.18, NES.css 2.3.0 (038-mobile-menu-fix)
 - N/A (静的サイト) (038-mobile-menu-fix)
+- TypeScript 5.x, Node.js 25.2.0 + Next.js 16.0.7, React 19.2.1, Tailwind CSS 3.4.18, NES.css 2.3.0 (039-fix-hydration-error)
+- sessionStorage (browser-side, for START gate persistence across page reloads) (039-fix-hydration-error)
 
 ## Recent Changes
 - 037-hero-image: Added TypeScript 5.x with Next.js 16.0.7 + Next.js (next/image for optimization), React 19.2.1, Tailwind CSS 3.4.18, NES.css 2.3.0

--- a/specs/039-fix-hydration-error/checklists/requirements.md
+++ b/specs/039-fix-hydration-error/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Fix Hydration Error and Start Gate Visibility
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-01-10
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- This feature has already been implemented (Status: Implemented)
+- Spec created retroactively to document the fix
+- Technical Solution section included for documentation purposes (acceptable for already-implemented features)

--- a/specs/039-fix-hydration-error/contracts/component-interfaces.md
+++ b/specs/039-fix-hydration-error/contracts/component-interfaces.md
@@ -1,0 +1,85 @@
+# Component Interfaces: Fix Hydration Error and Start Gate Visibility
+
+**Feature Branch**: `039-fix-hydration-error`
+
+## Overview
+
+This feature has no REST/GraphQL API. The "contracts" are internal component interfaces and hook signatures that define how the start gate system communicates across components.
+
+## Hook Interfaces
+
+### useHasMounted(): boolean
+
+```typescript
+/**
+ * Returns true once React has completed hydration on the client.
+ * Server snapshot always returns false.
+ * Used to prevent rendering client-only content during SSR.
+ */
+function useHasMounted(): boolean
+```
+
+**Contract**:
+- Server: always returns `false`
+- Client (first render): returns `true`
+- Never reverts to `false`
+- No dependencies or parameters
+
+### useStartGateStarted(): boolean
+
+```typescript
+/**
+ * Returns true when the START gate is open (is-started class on <html>).
+ * Subscribes to START_GATE_EVENT for reactive updates.
+ * Server snapshot always returns false.
+ */
+function useStartGateStarted(): boolean
+```
+
+**Contract**:
+- Server: always returns `false`
+- Client: reads `document.documentElement.classList.contains('is-started')`
+- Subscribes to `START_GATE_EVENT` on `document`
+- Transitions from `false` → `true` only (never reverts)
+
+## Event Interface
+
+### START_GATE_EVENT
+
+```typescript
+// Dispatched on document when gate state changes
+document.dispatchEvent(new Event("start-gate-change"));
+```
+
+**Contract**:
+- Dispatched by: `Hero.tsx` after `is-started` class is applied
+- Consumed by: `useStartGateStarted()` subscribe callback
+- Payload: none (consumers check classList directly)
+
+## CSS Contract
+
+### .start-gated
+
+```css
+/* Elements with this class are hidden until gate opens */
+html.not-started .start-gated,
+html.is-starting .start-gated {
+  display: none;
+}
+```
+
+**Contract**:
+- Any element with `className="start-gated"` is hidden before START
+- Elements become visible when `<html>` has `is-started` class
+- Works for server-rendered content without JavaScript
+- Does NOT affect Portal-rendered content (hence the need for hook-based gating)
+
+## sessionStorage Contract
+
+### portfolio.started.v1
+
+| Operation | When | Value |
+|-----------|------|-------|
+| Read | Page load (inline script in layout.tsx) | `"1"` if exists |
+| Write | User clicks PRESS START (Hero.tsx) | `"1"` |
+| Clear | Never (session ends when tab closes) | — |

--- a/specs/039-fix-hydration-error/data-model.md
+++ b/specs/039-fix-hydration-error/data-model.md
@@ -1,0 +1,87 @@
+# Data Model: Fix Hydration Error and Start Gate Visibility
+
+**Feature Branch**: `039-fix-hydration-error`
+**Date**: 2026-01-10
+
+## State Model
+
+This feature has no persistent data model (no database, no API). It manages ephemeral client-side state through DOM classes and sessionStorage.
+
+### Entity: StartGateState
+
+Represents the current state of the "PRESS START" gate.
+
+| Field | Type | Storage | Description |
+|-------|------|---------|-------------|
+| `gateClass` | `"not-started" \| "is-starting" \| "is-started"` | `document.documentElement.classList` | Current gate phase |
+| `persisted` | `"1" \| null` | `sessionStorage["portfolio.started.v1"]` | Whether START was pressed this session |
+
+### State Transitions
+
+```text
+                    ┌─────────────────────────────────┐
+                    │    Page Load                      │
+                    └───────────┬─────────────────────┘
+                                │
+                    ┌───────────▼───────────────────────┐
+                    │  Inline Script (layout.tsx)         │
+                    │  Check sessionStorage               │
+                    └───────────┬─────────────────────┘
+                                │
+                ┌───────────────┼────────────────────┐
+                │ (no storage)  │                      │ (storage = "1")
+                ▼               │                      ▼
+        ┌──────────────┐       │              ┌──────────────┐
+        │  not-started  │       │              │  is-started   │
+        └──────┬───────┘       │              └──────────────┘
+               │                │
+               │ User clicks    │
+               │ PRESS START    │
+               ▼                │
+        ┌──────────────┐       │
+        │  is-starting  │       │
+        │  (520ms anim) │       │
+        └──────┬───────┘       │
+               │                │
+               │ Animation done │
+               ▼                │
+        ┌──────────────┐       │
+        │  is-started   │───────┘
+        └──────────────┘
+```
+
+### Entity: MobileMenuVisibility
+
+Derived state controlling whether MobileMenu renders.
+
+| Field | Type | Source | Description |
+|-------|------|--------|-------------|
+| `mounted` | `boolean` | `useSyncExternalStore` (client snapshot: `true`, server: `false`) | React hydration complete |
+| `started` | `boolean` | `useSyncExternalStore` (reads `is-started` class) | Gate is open |
+| `visible` | `boolean` | `mounted && started` | Whether to render Portal content |
+
+### Relationships
+
+```text
+StartGateState.gateClass ──controls──▶ CSS .start-gated display
+StartGateState.gateClass ──observed-by──▶ useStartGateStarted() hook
+StartGateState.persisted ──read-by──▶ layout.tsx inline script
+MobileMenuVisibility.visible ──controls──▶ Portal rendering
+```
+
+### Validation Rules
+
+- `gateClass` must be exactly one of the three valid values at any time
+- `persisted` in sessionStorage is write-once per session (set on START, never cleared)
+- `mounted` can only transition from `false` to `true` (never reverts)
+- `started` can only transition from `false` to `true` (gate never closes)
+
+## Constants (startGate.ts)
+
+| Constant | Value | Usage |
+|----------|-------|-------|
+| `START_GATE_STORAGE_KEY` | `"portfolio.started.v1"` | sessionStorage key |
+| `START_GATE_CLASS_NOT_STARTED` | `"not-started"` | Initial HTML class |
+| `START_GATE_CLASS_STARTING` | `"is-starting"` | Animation phase class |
+| `START_GATE_CLASS_STARTED` | `"is-started"` | Final active class |
+| `START_GATE_EVENT` | `"start-gate-change"` | Custom event name |

--- a/specs/039-fix-hydration-error/plan.md
+++ b/specs/039-fix-hydration-error/plan.md
@@ -1,0 +1,83 @@
+# Implementation Plan: Fix Hydration Error and Start Gate Visibility
+
+**Branch**: `039-fix-hydration-error` | **Date**: 2026-01-10 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/039-fix-hydration-error/spec.md`
+
+## Summary
+
+Fix hydration mismatch errors and ensure the mobile hamburger menu is hidden behind the "PRESS START" gate. The root cause was MobileMenu using React Portal to render directly into `document.body`, bypassing the CSS-based `start-gated` visibility control. The fix uses `useSyncExternalStore` with separate server/client snapshots for safe hydration, plus a dual-gate (`mounted && started`) conditional rendering strategy in MobileMenu.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x, Node.js 25.2.0
+**Primary Dependencies**: Next.js 16.0.7, React 19.2.1, Tailwind CSS 3.4.18, NES.css 2.3.0
+**Storage**: sessionStorage (browser-side, for START gate persistence across page reloads)
+**Testing**: `pnpm lint` + `pnpm build` (no test framework configured; manual browser verification)
+**Target Platform**: Web (all modern browsers, mobile-first responsive)
+**Project Type**: Web (Next.js App Router, single project)
+**Performance Goals**: No layout shift on initial load; gate transition under 600ms
+**Constraints**: Zero hydration errors in console; mobile menu must not flash before START
+**Scale/Scope**: Single-page portfolio site, ~10 components affected
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+### Pre-Design Check (PASSED)
+
+| Principle | Status | Rationale |
+|-----------|--------|-----------|
+| **I. Personality-First Storytelling** | PASS | The "PRESS START" gate is a core personality element; fixing its reliability strengthens the storytelling |
+| **II. Retro Aesthetic, Modern Usability** | PASS | Fixes a UX regression (menu leaking through gate) while preserving retro boot animation |
+| **III. Content Is a Product Surface** | PASS | No content changes; structural fix only |
+| **IV. Lightweight, Fast, and Durable** | PASS | No new dependencies; uses built-in React APIs (`useSyncExternalStore`) |
+| **V. One Source of Truth, Kept in Sync** | PASS | No dependency/runtime changes; docs sync not required for this fix |
+
+**Quality Gates**:
+- `pnpm lint`: Must pass
+- `pnpm build`: Must pass
+
+**Docs Sync**: Not required (no dependency/script/runtime/deploy changes)
+
+### Post-Design Check (PASSED)
+
+Same as pre-design. The implementation adds no new patterns, dependencies, or architectural changes beyond the existing component structure.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/039-fix-hydration-error/
+├── plan.md              # This file
+├── research.md          # Phase 0: hydration strategy research
+├── data-model.md        # Phase 1: state model documentation
+├── quickstart.md        # Phase 1: developer quickstart
+├── checklists/          # Verification checklists
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── app/
+│   ├── layout.tsx            # Server: initial gate class + inline script
+│   ├── page.tsx              # Server: root page composition
+│   └── globals.css           # CSS gate rules (.start-gated display:none)
+├── components/
+│   ├── startGate.ts          # Constants: storage key, class names, event name
+│   ├── Hero.tsx              # Client: START button + useStartGateStarted hook
+│   ├── MobileMenu.tsx        # Client: dual-gate (mounted+started) + Portal
+│   └── TableOfContents.tsx   # Server: desktop menu (CSS-gated via parent div)
+```
+
+**Structure Decision**: Single Next.js project using App Router. All affected files are within the existing `src/` directory. No new directories needed.
+
+## Complexity Tracking
+
+> No constitution violations. The implementation uses only built-in React APIs and existing project patterns.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| (none)    | —          | —                                   |

--- a/specs/039-fix-hydration-error/quickstart.md
+++ b/specs/039-fix-hydration-error/quickstart.md
@@ -1,0 +1,91 @@
+# Quickstart: Fix Hydration Error and Start Gate Visibility
+
+**Feature Branch**: `039-fix-hydration-error`
+
+## Prerequisites
+
+- Node.js 25.2.0 (via nvm)
+- pnpm 10.13.1
+
+## Setup
+
+```bash
+source ~/.nvm/nvm.sh && nvm use 25.2.0
+git checkout 039-fix-hydration-error
+pnpm install
+```
+
+## Development
+
+```bash
+pnpm dev
+# Open http://localhost:3000
+```
+
+## Verification
+
+### Automated Checks
+
+```bash
+pnpm lint          # ESLint passes
+pnpm build         # Next.js production build passes
+```
+
+### Manual Verification
+
+1. **Initial Load (Mobile)**
+   - Open DevTools → Toggle device toolbar (mobile view)
+   - Reload the page
+   - Verify: Only Hero section with "PRESS START" button is visible
+   - Verify: No hamburger menu icon in top-right corner
+   - Verify: No hydration errors in browser console
+
+2. **After START (Mobile)**
+   - Click "PRESS START" button
+   - Verify: Boot animation plays (scanlines/vignette effect)
+   - Verify: After animation, hamburger menu icon appears in top-right
+   - Verify: Tapping hamburger opens the mobile menu overlay
+   - Verify: Menu items navigate correctly
+
+3. **Page Reload Persistence**
+   - After pressing START, reload the page
+   - Verify: Content appears immediately (no START gate)
+   - Verify: Hamburger menu is visible immediately
+   - Verify: No console errors
+
+4. **Reduced Motion**
+   - Enable "prefers-reduced-motion: reduce" in OS/browser settings
+   - Reload and press START
+   - Verify: No animation plays; content appears instantly
+
+5. **Desktop**
+   - View at desktop width (>640px)
+   - Verify: TableOfContents (sticky menu) is hidden before START
+   - Verify: TableOfContents appears after START
+   - Verify: MobileMenu hamburger is not visible (desktop uses TableOfContents)
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `src/components/startGate.ts` | Constants for gate state management |
+| `src/app/layout.tsx` | Server layout + inline session restore script |
+| `src/app/globals.css` | CSS rules for `.start-gated` visibility |
+| `src/components/Hero.tsx` | START button + `useStartGateStarted` hook |
+| `src/components/MobileMenu.tsx` | Dual-gate rendering + Portal |
+| `src/app/page.tsx` | Page composition with `start-gated` wrapper |
+
+## Architecture Overview
+
+```
+Server Render          Client Hydration         User Interaction
+─────────────         ──────────────────        ────────────────
+layout.tsx             useHasMounted()           Hero.onStart()
+  └─ html.not-started    └─ mounted=true          └─ is-starting
+  └─ inline script       useStartGateStarted()     └─ 520ms animation
+     (session restore)     └─ started=bool           └─ is-started
+                                                      └─ START_GATE_EVENT
+                         MobileMenu
+                           └─ if mounted && started
+                              └─ render Portal
+```

--- a/specs/039-fix-hydration-error/research.md
+++ b/specs/039-fix-hydration-error/research.md
@@ -1,0 +1,101 @@
+# Research: Fix Hydration Error and Start Gate Visibility
+
+**Feature Branch**: `039-fix-hydration-error`
+**Date**: 2026-01-10
+
+## Research Task 1: React Hydration Mismatch with Portal Components
+
+### Context
+MobileMenu used `createPortal(content, document.body)` to render outside the component tree. Portal-rendered elements bypass parent CSS classes like `start-gated`, causing the menu to be visible before the START gate opens. Additionally, the Portal target (`document.body`) doesn't exist during SSR, creating a hydration mismatch.
+
+### Decision
+Use `useSyncExternalStore` with separate server and client snapshots to safely detect client-side mounting and gate state.
+
+### Rationale
+- `useSyncExternalStore` is React's recommended API for subscribing to external stores with SSR support
+- The server snapshot always returns `false` (safe default: don't render)
+- The client snapshot reads the actual DOM state (`document.documentElement.classList`)
+- This eliminates the server/client mismatch that causes hydration errors
+
+### Alternatives Considered
+1. **`useEffect` + `useState`**: Causes a flash of incorrect content before the effect runs; not hydration-safe
+2. **`suppressHydrationWarning` on MobileMenu**: Only suppresses warnings, doesn't fix the underlying rendering issue
+3. **CSS-only hiding**: Insufficient because Portal renders outside the `start-gated` container
+4. **Remove Portal entirely**: Would fix the gating issue but creates iOS Safari fixed-positioning problems within scrollable containers
+
+## Research Task 2: Dual-Gate Pattern (mounted + started)
+
+### Context
+Two conditions must both be true before MobileMenu renders:
+1. React has finished hydrating (mounted)
+2. User has pressed START (started)
+
+### Decision
+Implement two independent hooks (`useHasMounted` and `useStartGateStarted`) and require both to be true.
+
+### Rationale
+- Separating concerns makes each hook testable and reusable
+- `useHasMounted` prevents any client-only rendering during SSR/hydration
+- `useStartGateStarted` tracks the business logic of the gate state
+- Combined check `if (!mounted || !started) return null` is clear and correct
+
+### Alternatives Considered
+1. **Single combined hook**: Less clear about which condition is failing; harder to debug
+2. **Context provider**: Adds unnecessary complexity for a simple boolean state
+3. **Global variable**: Not reactive; wouldn't trigger re-renders
+
+## Research Task 3: State Synchronization via Custom Events
+
+### Context
+The START gate state is managed by manipulating HTML element classes (in `layout.tsx` inline script and `Hero.tsx` click handler). React components need to react to these changes.
+
+### Decision
+Use a custom DOM event (`START_GATE_EVENT`) dispatched on `document` to notify subscribers when the gate state changes.
+
+### Rationale
+- Custom events are lightweight and built into the browser
+- `useSyncExternalStore`'s subscribe function maps naturally to `addEventListener`
+- No state management library needed
+- Works across component boundaries without prop drilling or context
+
+### Alternatives Considered
+1. **React Context + state lifting**: Would require restructuring component hierarchy; Hero and MobileMenu are not in a direct parent-child relationship
+2. **External state library (Zustand, Jotai)**: Overkill for a single boolean state; adds a dependency (violates Constitution Principle IV)
+3. **MutationObserver on classList**: More complex, less intentional; custom event is explicit
+
+## Research Task 4: Session Persistence of Gate State
+
+### Context
+When users reload the page, the START gate should remain open if they already pressed START during the session.
+
+### Decision
+Use `sessionStorage` with an inline `<script>` in `layout.tsx` that runs before React hydration.
+
+### Rationale
+- Inline script executes synchronously before first paint, preventing FOUC
+- `sessionStorage` scopes to the browser tab (not persisted across sessions, which is intentional for the "game start" experience)
+- `suppressHydrationWarning` on `<html>` allows the class change without React errors
+- The inline script is minimal (~5 lines) and has no dependencies
+
+### Alternatives Considered
+1. **`localStorage`**: Persists across sessions, which would remove the "PRESS START" experience on subsequent visits
+2. **Cookie-based**: Requires server-side logic; unnecessary complexity
+3. **React state only**: Would cause a flash of the gate on every reload even for returning users
+
+## Research Task 5: Portal Retention vs Removal
+
+### Context
+The original MobileMenu used a Portal. The spec mentions "Portal廃止" (Portal removal) as part of the solution.
+
+### Decision
+Retain the Portal but make it conditional on `mounted && started`. The Portal is still used when the menu renders.
+
+### Rationale
+- Portal solves real iOS Safari issues with fixed positioning inside scrollable containers
+- The hydration problem was not the Portal itself, but rendering it unconditionally
+- Conditional rendering (`if (!mounted || !started) return null`) means the Portal is never created during SSR or before START
+- No Portal during SSR = no hydration mismatch
+
+### Alternatives Considered
+1. **Remove Portal entirely**: Simpler but would reintroduce iOS Safari positioning bugs
+2. **Lazy-load Portal target**: Unnecessary complexity; conditional rendering achieves the same goal

--- a/specs/039-fix-hydration-error/tasks.md
+++ b/specs/039-fix-hydration-error/tasks.md
@@ -1,0 +1,181 @@
+# Tasks: Fix Hydration Error and Start Gate Visibility
+
+**Input**: Design documents from `/specs/039-fix-hydration-error/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/
+
+**Tests**: No test framework configured. Verification is `pnpm lint` + `pnpm build` + manual browser checks (per quickstart.md).
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Project type**: Single Next.js App Router project
+- **Source**: `src/` at repository root
+- **Components**: `src/components/`
+- **App**: `src/app/`
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Extract gate constants into a shared module so all components reference the same values
+
+- [ ] T001 Create start gate constants module with storage key, class names, and event name in `src/components/startGate.ts`
+
+**Checkpoint**: Constants module exists and exports `START_GATE_STORAGE_KEY`, `START_GATE_CLASS_NOT_STARTED`, `START_GATE_CLASS_STARTING`, `START_GATE_CLASS_STARTED`, `START_GATE_EVENT`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Establish the CSS gating system and server-side session restore that all user stories depend on
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [ ] T002 Add CSS rules for `.start-gated` visibility gating (`display: none` when `html.not-started` or `html.is-starting`) in `src/app/globals.css`
+- [ ] T003 Add `not-started` default class to `<html>` element and inline `<script>` that checks `sessionStorage` for `portfolio.started.v1` and applies `is-started` class before first paint in `src/app/layout.tsx`
+- [ ] T004 Add `suppressHydrationWarning` to `<html>` element in `src/app/layout.tsx` to allow the inline script class changes without React hydration errors
+- [ ] T005 Wrap main content sections in a `<div className="start-gated">` container in `src/app/page.tsx`
+
+**Checkpoint**: Foundation ready — page loads with `html.not-started`; CSS hides `.start-gated` content; sessionStorage restore applies `is-started` on reload; no hydration warnings from `<html>` class changes
+
+---
+
+## Phase 3: User Story 1 — Initial Page Load Experience (Priority: P1) 🎯 MVP
+
+**Goal**: On initial page load, only the Hero section with "PRESS START" button is visible. The mobile hamburger menu and all gated content are hidden. No hydration errors occur.
+
+**Independent Test**: Open the site on a mobile device. Before pressing START, verify no hamburger menu icon is visible and browser console shows zero hydration errors.
+
+### Implementation for User Story 1
+
+- [ ] T006 [US1] Implement `useHasMounted()` hook using `useSyncExternalStore` with server snapshot returning `false` and client snapshot returning `true` in `src/components/MobileMenu.tsx`
+- [ ] T007 [US1] Implement `useStartGateStarted()` hook using `useSyncExternalStore` that subscribes to `START_GATE_EVENT` and reads `is-started` class from `document.documentElement` in `src/components/Hero.tsx`
+- [ ] T008 [US1] Add dual-gate conditional rendering to MobileMenu: return `null` when `!mounted || !started` (before the Portal render) in `src/components/MobileMenu.tsx`
+- [ ] T009 [US1] Update Hero component `onStart()` handler to set sessionStorage, apply class transitions (`not-started` → `is-starting` → `is-started`), and dispatch `START_GATE_EVENT` in `src/components/Hero.tsx`
+- [ ] T010 [US1] Add boot animation CSS for `html.is-starting` state (scanlines/vignette effect, 520ms duration) in `src/app/globals.css`
+- [ ] T011 [US1] Add `prefers-reduced-motion` media query to skip boot animation when reduced motion is preferred in `src/app/globals.css`
+- [ ] T012 [US1] Run `pnpm lint` and `pnpm build` to verify no errors
+
+**Checkpoint**: User Story 1 fully functional — page loads with only Hero visible; no hamburger menu before START; no hydration errors in console; `pnpm build` passes
+
+---
+
+## Phase 4: User Story 2 — Post-START Menu Visibility (Priority: P2)
+
+**Goal**: After pressing "PRESS START", the mobile hamburger menu appears and functions correctly (open/close, navigation, scroll lock).
+
+**Independent Test**: Press START button, then verify hamburger icon appears in top-right on mobile view; tap it to open the menu overlay; tap a menu item to navigate.
+
+### Implementation for User Story 2
+
+- [ ] T013 [US2] Ensure MobileMenu Portal renders correctly after both `mounted` and `started` become true — verify button and overlay content are created via `createPortal(content, document.body)` in `src/components/MobileMenu.tsx`
+- [ ] T014 [US2] Verify existing menu functionality is preserved: hamburger toggle, overlay open/close, menu item click navigation, keyboard accessibility, focus trap, scroll lock in `src/components/MobileMenu.tsx`
+- [ ] T015 [US2] Verify page reload persistence — after pressing START, reload the page and confirm hamburger menu appears immediately (sessionStorage-based restore) via manual browser test
+- [ ] T016 [US2] Run `pnpm lint` and `pnpm build` to verify no errors
+
+**Checkpoint**: User Stories 1 AND 2 both work independently — menu hidden before START, visible and functional after START, persists across reloads
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: Improvements that affect multiple user stories and final validation
+
+- [ ] T017 Verify desktop behavior: TableOfContents (sticky menu) is CSS-gated and hidden before START, visible after START in `src/components/TableOfContents.tsx`
+- [ ] T018 Verify reduced-motion behavior across all gate transitions (no animation when `prefers-reduced-motion: reduce` is active) via manual browser test
+- [ ] T019 Run full verification suite: `pnpm format:check && pnpm lint && pnpm build`
+- [ ] T020 Run quickstart.md manual verification checklist (all 5 scenarios from `specs/039-fix-hydration-error/quickstart.md`)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately
+- **Foundational (Phase 2)**: Depends on Setup (T001) — BLOCKS all user stories
+- **User Story 1 (Phase 3)**: Depends on Foundational (Phase 2) completion
+- **User Story 2 (Phase 4)**: Depends on User Story 1 (Phase 3) — US2 needs the gate hooks implemented in US1
+- **Polish (Phase 5)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Foundational (Phase 2) — No dependencies on other stories
+- **User Story 2 (P2)**: Depends on US1 — needs `useHasMounted()` and `useStartGateStarted()` hooks and the dual-gate pattern to be in place before testing post-START behavior
+
+### Within Each User Story
+
+- Constants (startGate.ts) before hooks
+- Hooks before conditional rendering
+- CSS rules before animation verification
+- Core implementation before lint/build check
+- Commit after each task or logical group
+
+### Parallel Opportunities
+
+- T002 and T003/T004 can run in parallel (different files: globals.css vs layout.tsx)
+- T006 and T007 can run in parallel (different files: MobileMenu.tsx vs Hero.tsx)
+- T010 and T011 can run in parallel (additive CSS rules, no conflicts)
+- T017 and T018 can run in parallel (independent verification scenarios)
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Launch hooks for User Story 1 together (different files):
+Task: "Implement useHasMounted() in src/components/MobileMenu.tsx"
+Task: "Implement useStartGateStarted() in src/components/Hero.tsx"
+
+# Launch CSS tasks together (additive, no conflicts):
+Task: "Add boot animation CSS in src/app/globals.css"
+Task: "Add reduced-motion media query in src/app/globals.css"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (T001)
+2. Complete Phase 2: Foundational (T002–T005)
+3. Complete Phase 3: User Story 1 (T006–T012)
+4. **STOP and VALIDATE**: Test User Story 1 independently — mobile load shows no menu, no hydration errors
+5. Deploy/demo if ready
+
+### Incremental Delivery
+
+1. Complete Setup + Foundational → Foundation ready
+2. Add User Story 1 → Test independently → Deploy (MVP — gate works, menu hidden)
+3. Add User Story 2 → Test independently → Deploy (full fix — menu works post-START)
+4. Polish → Final validation → Production-ready
+
+### File Impact Summary
+
+| File | Tasks | Changes |
+|------|-------|---------|
+| `src/components/startGate.ts` | T001 | New: constants module |
+| `src/app/globals.css` | T002, T010, T011 | Add: gate CSS + boot animation + reduced-motion |
+| `src/app/layout.tsx` | T003, T004 | Modify: add class, inline script, suppressHydrationWarning |
+| `src/app/page.tsx` | T005 | Modify: wrap content in `start-gated` div |
+| `src/components/Hero.tsx` | T007, T009 | Modify: add hook + update onStart handler |
+| `src/components/MobileMenu.tsx` | T006, T008, T013, T014 | Modify: add hooks + dual-gate rendering |
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Each user story should be independently completable and testable
+- Commit after each task or logical group
+- Stop at any checkpoint to validate story independently
+- No test framework tasks: verification is `pnpm lint` + `pnpm build` + manual browser checks


### PR DESCRIPTION
## Summary
- Generated implementation plan, research, data model, contracts, quickstart, and task list for the hydration fix feature
- Updated CLAUDE.md agent context with feature technology info
- All artifacts created via `/speckit.plan` and `/speckit.tasks` workflow

## Artifacts
- `specs/039-fix-hydration-error/plan.md` — Implementation plan with constitution check
- `specs/039-fix-hydration-error/research.md` — 5 research decisions (hydration strategy, dual-gate, events, session persistence, Portal retention)
- `specs/039-fix-hydration-error/data-model.md` — State model and transitions
- `specs/039-fix-hydration-error/contracts/component-interfaces.md` — Hook and event interfaces
- `specs/039-fix-hydration-error/quickstart.md` — Developer quickstart with manual verification checklist
- `specs/039-fix-hydration-error/tasks.md` — 20 tasks across 5 phases (2 user stories)

## Test plan
- [x] Documentation only — no code changes
- [x] `pnpm lint` and `pnpm build` unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)